### PR TITLE
Fix multiple source empty error 

### DIFF
--- a/lib/Exporter/Source/ChainSourceIterator.php
+++ b/lib/Exporter/Source/ChainSourceIterator.php
@@ -66,7 +66,7 @@ class ChainSourceIterator implements SourceIteratorInterface
      */
     public function valid()
     {
-        if (!$this->sources->current()->valid()) {
+        while (!$this->sources->current()->valid()) {
             $this->sources->next();
 
             if (!$this->sources->valid()) {


### PR DESCRIPTION
When you retrieve data in several empty tables. In the second source iterator the current is empty but validate.
With this fix, we valid each iterator.
