### PR TITLE
Add missing group node to GsaFeedWriter

### DIFF
--- a/lib/Exporter/Writer/GsaFeedWriter.php
+++ b/lib/Exporter/Writer/GsaFeedWriter.php
@@ -153,7 +153,6 @@ XML
         fwrite($this->buffer, <<<EOF
     </group>
 </gsafeed>
-
 EOF
         );
 

--- a/test/Exporter/Test/Writer/GsaFeedWriterTest.php
+++ b/test/Exporter/Test/Writer/GsaFeedWriterTest.php
@@ -92,8 +92,11 @@ class GsaFeedWriterTest extends \PHPUnit_Framework_TestCase
         <datasource>$this->datasource</datasource>
         <feedtype>$this->feedtype</feedtype>
     </header>
-    <record url="http://sonata-project.org/about" mimetype="text/html" action="add"/>
-    <record url="http://sonata-project.org/bundles/" mimetype="text/html" action="delete"/>
+
+    <group>
+        <record url="http://sonata-project.org/about" mimetype="text/html" action="add"/>
+        <record url="http://sonata-project.org/bundles/" mimetype="text/html" action="delete"/>
+    </group>
 </gsafeed>
 XML;
 


### PR DESCRIPTION
The Google Search Appliance feed DTD requires a `<group>` node parent to all `<record>` nodes.
Here is the document type definition: https://developers.google.com/search-appliance/documentation/64/feedsguide#gsafeed_dtd
