### PR TITLE
[XmlExcelWriter] Dot not force column types on the first line when showing headers

### DIFF
--- a/lib/Exporter/Writer/XmlExcelWriter.php
+++ b/lib/Exporter/Writer/XmlExcelWriter.php
@@ -93,7 +93,10 @@ class XmlExcelWriter implements WriterInterface
             $value = htmlspecialchars($value);
             //$value = htmlentities($value);
             $value = str_replace(array("\r\n", "\r", "\n"), '&#10;', $value);
-            $dataType = $this->getDataType($key, $value);
+            $dataType = 'String';
+            if ($this->position != 0 || !$this->showHeaders) {
+                $dataType = $this->getDataType($key, $value);
+            }
             $xmlData[] = '<Cell><Data ss:Type="' . $dataType . '">' . $value . '</Data></Cell>';
         }
         $xmlData[] = '</Row>';

--- a/test/Exporter/Test/Writer/XmlExcelWriterTest.php
+++ b/test/Exporter/Test/Writer/XmlExcelWriterTest.php
@@ -61,6 +61,22 @@ class XmlExcelWriterTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue(strstr(file_get_contents($this->filename), $expected) !== false);
     }
 
+    public function testForceTypesWithHeaders()
+    {
+        // force all cells to have Number type
+        $writer = new XmlExcelWriter($this->filename, true, 'Number');
+        $writer->open();
+
+        $writer->write(array('name' => 'john', 'surname' => 'doe ', 'year' => '2001'));
+
+        $writer->close();
+
+        $expected = '<Row><Cell><Data ss:Type="String">name</Data></Cell><Cell><Data ss:Type="String">surname</Data></Cell><Cell><Data ss:Type="String">year</Data></Cell></Row>';
+        $expected .= '<Row><Cell><Data ss:Type="Number">john</Data></Cell><Cell><Data ss:Type="Number">doe </Data></Cell><Cell><Data ss:Type="Number">2001</Data></Cell></Row>';
+
+        $this->assertTrue(strstr(file_get_contents($this->filename), $expected) !== false);
+    }
+
     public function testSpecificTypes()
     {
         // define type for specific cell


### PR DESCRIPTION
The column type must be `String` for the first line if headers are shown in XmlExcelWriter
