### PR TITLE
Travis: Run composer install before running phpunit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,7 @@ php:
   - 5.4
   - 5.5
 
+before_script:
+  - composer install --dev --prefer-source
+
 script: phpunit --coverage-text


### PR DESCRIPTION
Composer install is missing in travis. Without this the dependencies are missing.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |
