### PR TITLE
Allow magic _call for DoctrineORMQuerySourceIterator

### DIFF
--- a/lib/Exporter/Source/DoctrineORMQuerySourceIterator.php
+++ b/lib/Exporter/Source/DoctrineORMQuerySourceIterator.php
@@ -58,7 +58,9 @@ class DoctrineORMQuerySourceIterator implements SourceIteratorInterface
         // Note : will be deprecated in Symfony 3.0, conserved for 2.2 compatibility
         // Use createPropertyAccessor() for 3.0
         // @see Symfony\Component\PropertyAccess\PropertyAccess
-        $this->propertyAccessor = PropertyAccess::getPropertyAccessor();
+        $this->propertyAccessor = PropertyAccess::createPropertyAccessorBuilder()
+                        ->enableMagicCall()
+                        ->getPropertyAccessor();
 
         $this->propertyPaths = array();
         foreach ($fields as $name => $field) {


### PR DESCRIPTION
In the same idea of https://github.com/sonata-project/SonataAdminBundle/pull/2262, extend usability
See http://a2lix.fr/blog/2014/08/04/translate-internationalize-doctrine-entities-sonata.html