### PR TITLE
Fix deprecated PropertyAccess::getPropertyAccessor usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ A [BC BREAK] means the update will break the project for many reasons:
 * new dependencies
 * class refactoring
 
+### 2015-06-09
+
+* [BC BREAK] Replaced deprecated `PropertyAccess::getPropertyAccessor()` method `PropertyAccess::createPropertyAccessor()`.
+             Symfony 2.2 support dropped.
+
 ### 2013-05-02
 
 * [BC BREAK] New argument in method \Exporter\Writer\SitemapWriter::generateSitemapIndex

--- a/README.md
+++ b/README.md
@@ -46,10 +46,11 @@ For questions and proposals you can post on this google groups
 
 * [Sonata Users](https://groups.google.com/group/sonata-users): Only for user questions
 * [Sonata Devs](https://groups.google.com/group/sonata-devs): Only for devs
- 
 
-### Note for symfony2 users
 
-* For >= symfony2.2, use tag 1.3.1
-* For symfony2.1, use tag 1.2.3
-* For symfony2.0, use tag 1.1.0
+### Note for Symfony2 users
+
+* For Symfony >=2.3, use tag `^1.4`
+* For Symfony 2.2, use tag 1.3.1
+* For Symfony 2.1, use tag 1.2.3
+* For Ssymfony 2.0, use tag 1.1.0

--- a/composer.json
+++ b/composer.json
@@ -17,14 +17,14 @@
     },
     "require-dev": {
         "symfony/routing": "*",
-        "symfony/property-access": "~2.2",
+        "symfony/property-access": "~2.3",
         "symfony/phpunit-bridge": "~2.7",
         "propel/propel1": "~1.6"
     },
     "suggest": {
         "ext-curl": "*",
         "symfony/routing": "*",
-        "symfony/property-access": "~2.2",
+        "symfony/property-access": "~2.3",
         "propel/propel1": "~1.6"
     },
     "autoload": {

--- a/lib/Exporter/Source/DoctrineODMQuerySourceIterator.php
+++ b/lib/Exporter/Source/DoctrineODMQuerySourceIterator.php
@@ -50,10 +50,7 @@ class DoctrineODMQuerySourceIterator implements SourceIteratorInterface
     {
         $this->query = clone $query;
 
-        // Note : will be deprecated in Symfony 3.0, conserved for 2.2 compatibility
-        // Use createPropertyAccessor() for 3.0
-        // @see Symfony\Component\PropertyAccess\PropertyAccess
-        $this->propertyAccessor = PropertyAccess::getPropertyAccessor();
+        $this->propertyAccessor = PropertyAccess::createPropertyAccessor();
 
         $this->propertyPaths = array();
         foreach ($fields as $name => $field) {

--- a/lib/Exporter/Source/DoctrineORMQuerySourceIterator.php
+++ b/lib/Exporter/Source/DoctrineORMQuerySourceIterator.php
@@ -55,10 +55,7 @@ class DoctrineORMQuerySourceIterator implements SourceIteratorInterface
             $this->query->setHint($name, $value);
         }
 
-        // Note : will be deprecated in Symfony 3.0, conserved for 2.2 compatibility
-        // Use createPropertyAccessor() for 3.0
-        // @see Symfony\Component\PropertyAccess\PropertyAccess
-        $this->propertyAccessor = PropertyAccess::getPropertyAccessor();
+        $this->propertyAccessor = PropertyAccess::createPropertyAccessor();
 
         $this->propertyPaths = array();
         foreach ($fields as $name => $field) {

--- a/lib/Exporter/Source/PropelCollectionSourceIterator.php
+++ b/lib/Exporter/Source/PropelCollectionSourceIterator.php
@@ -56,10 +56,7 @@ class PropelCollectionSourceIterator implements SourceIteratorInterface
     {
         $this->collection = clone $collection;
 
-        // Note : will be deprecated in Symfony 3.0, conserved for 2.2 compatibility
-        // Use createPropertyAccessor() for 3.0
-        // @see Symfony\Component\PropertyAccess\PropertyAccess
-        $this->propertyAccessor = PropertyAccess::getPropertyAccessor();
+        $this->propertyAccessor = PropertyAccess::createPropertyAccessor();
 
         $this->propertyPaths = array();
         foreach ($fields as $name => $field) {


### PR DESCRIPTION
Symfony 2.2 support drop as this version is not supported anymore.

Must be tag as a new minor version (e.g. `1.4`)