### PR TITLE
[XmlSourceIterator] Add possibility to set custom tag names

### DIFF
--- a/lib/Exporter/Source/XmlSourceIterator.php
+++ b/lib/Exporter/Source/XmlSourceIterator.php
@@ -18,12 +18,19 @@ namespace Exporter\Source;
  */
 class XmlSourceIterator extends AbstractXmlSourceIterator
 {
+    protected $mainTag;
+    protected $dataTag;
+
     /**
      * @param string $filename
+     * @param string $mainTag
+     * @param string $dataTag
      */
-    public function __construct($filename)
+    public function __construct($filename, $mainTag = 'datas', $dataTag = 'data')
     {
         parent::__construct($filename, false);
+        $this->mainTag = $mainTag;
+        $this->dataTag = $dataTag;
     }
 
     /**
@@ -51,9 +58,9 @@ class XmlSourceIterator extends AbstractXmlSourceIterator
     public function tagStart($parser, $name, $attributes = array())
     {
         switch ($name) {
-            case 'datas':
+            case $this->mainTag:
                 break;
-            case 'data':
+            case $this->dataTag:
                 $this->bufferedRow['i_'.$this->currentRowIndex] = array();
                 break;
             default:
@@ -75,9 +82,9 @@ class XmlSourceIterator extends AbstractXmlSourceIterator
     public function tagEnd($parser, $name)
     {
         switch ($name) {
-            case 'datas':
+            case $this->mainTag:
                 break;
-            case 'data':
+            case $this->dataTag:
                 $this->currentRowIndex++;
                 $this->currentColumnIndex = 0;
                 $this->currentRowEnded = true;

--- a/test/Exporter/Test/Source/XmlSourceIteratorTest.php
+++ b/test/Exporter/Test/Source/XmlSourceIteratorTest.php
@@ -7,17 +7,18 @@ use Exporter\Source\XmlSourceIterator;
 class XmlSourceIteratorTest extends \PHPUnit_Framework_TestCase
 {
     protected $filename;
+    protected $filenameCustomTagNames;
 
     public function setUp()
     {
-        $this->filename = 'foobar.xml';
-
-        if (is_file($this->filename)) {
-            unlink($this->filename);
-        }
-
+        $this->filename = 'source_xml.xml';
         $xml = '<?xml version="1.0" ?><datas><data><sku><![CDATA[123]]></sku><ean><![CDATA[1234567891234]]></ean><name><![CDATA[Product é]]></name></data><data><sku><![CDATA[124]]></sku><ean><![CDATA[1234567891235]]></ean><name><![CDATA[Product @]]></name></data><data><sku><![CDATA[125]]></sku><ean><![CDATA[1234567891236]]></ean><name><![CDATA[Product 3 ©]]></name></data></datas>';
-        file_put_contents($this->filename, $xml);
+        $this->createXmlFile($this->filename, $xml);
+
+        // for custom tag names
+        $this->filenameCustomTagNames = 'source_xml_custom_tag_names.xml';
+        $xml = '<?xml version="1.0" ?><channel><item><sku><![CDATA[123]]></sku><ean><![CDATA[1234567891234]]></ean><name><![CDATA[Product é]]></name></item><item><sku><![CDATA[124]]></sku><ean><![CDATA[1234567891235]]></ean><name><![CDATA[Product @]]></name></item><item><sku><![CDATA[125]]></sku><ean><![CDATA[1234567891236]]></ean><name><![CDATA[Product 3 ©]]></name></item></channel>';
+        $this->createXmlFile($this->filenameCustomTagNames, $xml);
     }
 
     public function testHandler()
@@ -59,8 +60,36 @@ class XmlSourceIteratorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(3, $i);
     }
 
+    public function testCustomTagNames()
+    {
+        $iterator = new XmlSourceIterator($this->filenameCustomTagNames, 'channel', 'item');
+
+        $i = 0;
+        foreach ($iterator as $value) {
+            $this->assertTrue(is_array($value));
+            $this->assertEquals(3, count($value));
+            $keys = array_keys($value);
+            $this->assertEquals($i, $iterator->key());
+            $this->assertEquals('sku', $keys[0]);
+            $this->assertEquals('ean', $keys[1]);
+            $this->assertEquals('name', $keys[2]);
+            ++$i;
+        }
+        $this->assertEquals(3, $i);
+    }
+
     public function tearDown()
     {
         unlink($this->filename);
+        unlink($this->filenameCustomTagNames);
+    }
+
+    protected function createXmlFile($filename, $content)
+    {
+        if (is_file($filename)) {
+            unlink($filename);
+        }
+
+        file_put_contents($filename, $content);
     }
 }


### PR DESCRIPTION
Add possibility to set custom tag names for the XmlSourceIterator.

e.g: Can be used to parse files like this : 
```xml
<?xml version="1.0" ?>
<channel>
    <item>
        ...
    </item>
    <item>
        ...
    </item>
</channel>
```
by passing tag names to the constructor
```php
$source = new XmlSourceIterator($filename, 'channel', 'item');
```

No BC Break as the default values for the tag names are `datas`and `data`.

ping @Soullivaneuh @rande 