### PR TITLE
When applicable, provide mime type

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,11 @@
             "Exporter\\": "src/"
         }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "Exporter\\Test\\": "test/"
+        }
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "1.x-dev"

--- a/docs/reference/outputs.rst
+++ b/docs/reference/outputs.rst
@@ -13,4 +13,6 @@ Several output formatters are supported:
 * Excel XML
 * XLS (MS Excel)
 
-You may also create your own. To do so, simply create a class that implements the ``Exporter\Writer\WriterInterface``.
+You may also create your own. To do so, simply create a class that implements the ``Exporter\Writer\WriterInterface``,
+or better, if you know what ``Content-Type`` header should be used along with
+your output and what format it produces, ``TypedWriterInterface``.

--- a/src/Writer/CsvWriter.php
+++ b/src/Writer/CsvWriter.php
@@ -13,7 +13,7 @@ namespace Exporter\Writer;
 
 use Exporter\Exception\InvalidDataFormatException;
 
-class CsvWriter implements WriterInterface
+class CsvWriter implements TypedWriterInterface
 {
     /**
      * @var string
@@ -76,6 +76,22 @@ class CsvWriter implements WriterInterface
         if (is_file($filename)) {
             throw new \RuntimeException(sprintf('The file %s already exist', $filename));
         }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    final public function getDefaultMimeType()
+    {
+        return 'text/csv';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    final public function getFormat()
+    {
+        return 'csv';
     }
 
     /**

--- a/src/Writer/CsvWriter.php
+++ b/src/Writer/CsvWriter.php
@@ -13,6 +13,9 @@ namespace Exporter\Writer;
 
 use Exporter\Exception\InvalidDataFormatException;
 
+/**
+ * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ */
 class CsvWriter implements TypedWriterInterface
 {
     /**

--- a/src/Writer/JsonWriter.php
+++ b/src/Writer/JsonWriter.php
@@ -11,6 +11,9 @@
 
 namespace Exporter\Writer;
 
+/**
+ * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ */
 class JsonWriter implements TypedWriterInterface
 {
     /**

--- a/src/Writer/JsonWriter.php
+++ b/src/Writer/JsonWriter.php
@@ -11,7 +11,7 @@
 
 namespace Exporter\Writer;
 
-class JsonWriter implements WriterInterface
+class JsonWriter implements TypedWriterInterface
 {
     /**
      * @var string
@@ -39,6 +39,22 @@ class JsonWriter implements WriterInterface
         if (is_file($filename)) {
             throw new \RuntimeException(sprintf('The file %s already exist', $filename));
         }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    final public function getDefaultMimeType()
+    {
+        return 'application/json';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    final public function getFormat()
+    {
+        return 'json';
     }
 
     /**

--- a/src/Writer/TypedWriterInterface.php
+++ b/src/Writer/TypedWriterInterface.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Exporter\Writer;
+
+/**
+ * @author Grégoire Paris <postmaster@greg0ire.fr>
+ */
+interface TypedWriterInterface extends WriterInterface
+{
+    /**
+     * There can be several mime types for a given format, this method should
+     * return the most appopriate / popular one.
+     *
+     * @return string the mime type of the output
+     */
+    public function getDefaultMimeType();
+
+    /**
+     * Returns a string best describing the format of the output (the file
+     * extension is fine, for example).
+     *
+     * @return string a string without spaces, usable in a translation string
+     */
+    public function getFormat();
+}

--- a/src/Writer/XlsWriter.php
+++ b/src/Writer/XlsWriter.php
@@ -11,7 +11,7 @@
 
 namespace Exporter\Writer;
 
-class XlsWriter implements WriterInterface
+class XlsWriter implements TypedWriterInterface
 {
     /**
      * @var string
@@ -48,6 +48,22 @@ class XlsWriter implements WriterInterface
         if (is_file($filename)) {
             throw new \RuntimeException(sprintf('The file %s already exist', $filename));
         }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    final public function getDefaultMimeType()
+    {
+        return 'application/vnd.ms-excel';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    final public function getFormat()
+    {
+        return 'xls';
     }
 
     /**

--- a/src/Writer/XlsWriter.php
+++ b/src/Writer/XlsWriter.php
@@ -11,6 +11,9 @@
 
 namespace Exporter\Writer;
 
+/**
+ * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ */
 class XlsWriter implements TypedWriterInterface
 {
     /**

--- a/src/Writer/XmlWriter.php
+++ b/src/Writer/XmlWriter.php
@@ -13,7 +13,7 @@ namespace Exporter\Writer;
 
 use Exporter\Exception\InvalidDataFormatException;
 
-class XmlWriter implements WriterInterface
+class XmlWriter implements TypedWriterInterface
 {
     /**
      * @var string
@@ -55,6 +55,22 @@ class XmlWriter implements WriterInterface
         if (is_file($filename)) {
             throw new \RuntimeException(sprintf('The file %s already exist', $filename));
         }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    final public function getDefaultMimeType()
+    {
+        return 'text/xml';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    final public function getFormat()
+    {
+        return 'xml';
     }
 
     /**

--- a/src/Writer/XmlWriter.php
+++ b/src/Writer/XmlWriter.php
@@ -13,6 +13,9 @@ namespace Exporter\Writer;
 
 use Exporter\Exception\InvalidDataFormatException;
 
+/**
+ * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ */
 class XmlWriter implements TypedWriterInterface
 {
     /**

--- a/test/Writer/AbstractTypedWriterTestCase.php
+++ b/test/Writer/AbstractTypedWriterTestCase.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Exporter\Test\Writer;
+
+use Exporter\Writer\WriterInterface;
+
+/**
+ * @author Grégoire Paris <postmaster@greg0ire.fr>
+ */
+abstract class AbstractTypedWriterTestCase extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var WriterInterface
+     */
+    private $writer;
+
+    protected function setUp()
+    {
+        $this->writer = $this->getWriter();
+    }
+
+    public function testFormatIsString()
+    {
+        $this->assertInternalType('string', $this->writer->getFormat());
+    }
+
+    public function testDefaultMimeTypeIsString()
+    {
+        $this->assertInternalType('string', $this->writer->getDefaultMimeType());
+    }
+
+    /**
+     * Should return a very simple instance of the writer (no need for complex
+     * configuration).
+     *
+     * @return WriterInterface
+     */
+    abstract protected function getWriter();
+}

--- a/test/Writer/CsvWriterTest.php
+++ b/test/Writer/CsvWriterTest.php
@@ -13,12 +13,13 @@ namespace Exporter\Test\Writer;
 
 use Exporter\Writer\CsvWriter;
 
-class CsvWriterTest extends \PHPUnit_Framework_TestCase
+class CsvWriterTest extends AbstractTypedWriterTestCase
 {
     protected $filename;
 
     public function setUp()
     {
+        parent::setUp();
         $this->filename = 'foobar.csv';
 
         if (is_file($this->filename)) {
@@ -28,7 +29,9 @@ class CsvWriterTest extends \PHPUnit_Framework_TestCase
 
     public function tearDown()
     {
-        unlink($this->filename);
+        if (is_file($this->filename)) {
+            unlink($this->filename);
+        }
     }
 
     /**
@@ -95,5 +98,10 @@ class CsvWriterTest extends \PHPUnit_Framework_TestCase
 
         $expected = chr(0xEF).chr(0xBB).chr(0xBF).'name,surname,year'."\n".'"Rémi , """"2""","doe ",2001';
         $this->assertEquals($expected, trim(file_get_contents($this->filename)));
+    }
+
+    protected function getWriter()
+    {
+        return new CsvWriter('/tmp/whatever.csv');
     }
 }

--- a/test/Writer/JsonWriterTest.php
+++ b/test/Writer/JsonWriterTest.php
@@ -13,12 +13,13 @@ namespace Exporter\Test\Writer;
 
 use Exporter\Writer\JsonWriter;
 
-class JsonWriterTest extends \PHPUnit_Framework_TestCase
+class JsonWriterTest extends AbstractTypedWriterTestCase
 {
     protected $filename;
 
     public function setUp()
     {
+        parent::setUp();
         $this->filename = 'foobar.json';
 
         if (is_file($this->filename)) {
@@ -28,7 +29,9 @@ class JsonWriterTest extends \PHPUnit_Framework_TestCase
 
     public function tearDown()
     {
-        unlink($this->filename);
+        if (is_file($this->filename)) {
+            unlink($this->filename);
+        }
     }
 
     public function testWrite()
@@ -52,5 +55,10 @@ class JsonWriterTest extends \PHPUnit_Framework_TestCase
         );
 
         $this->assertEquals($expected, json_decode($content, false));
+    }
+
+    protected function getWriter()
+    {
+        return new JsonWriter('/tmp/whatever.json');
     }
 }

--- a/test/Writer/XlsWriterTest.php
+++ b/test/Writer/XlsWriterTest.php
@@ -13,12 +13,13 @@ namespace Exporter\Test\Writer;
 
 use Exporter\Writer\XlsWriter;
 
-class XlsWriterTest extends \PHPUnit_Framework_TestCase
+class XlsWriterTest extends AbstractTypedWriterTestCase
 {
     protected $filename;
 
     public function setUp()
     {
+        parent::setUp();
         $this->filename = 'foobar.xls';
 
         if (is_file($this->filename)) {
@@ -28,7 +29,9 @@ class XlsWriterTest extends \PHPUnit_Framework_TestCase
 
     public function tearDown()
     {
-        unlink($this->filename);
+        if (is_file($this->filename)) {
+            unlink($this->filename);
+        }
     }
 
     public function testValidDataFormat()
@@ -55,5 +58,10 @@ class XlsWriterTest extends \PHPUnit_Framework_TestCase
         $expected = '<html><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8" /><meta name=ProgId content=Excel.Sheet><meta name=Generator content="https://github.com/sonata-project/exporter"></head><body><table><tr><th>firtname</th><th>surname</th><th>year</th></tr><tr><td>john "2</td><td>doe</td><td>1</td></tr></table></body></html>';
 
         $this->assertEquals($expected, trim(file_get_contents($this->filename)));
+    }
+
+    protected function getWriter()
+    {
+        return new XlsWriter('/tmp/whatever.xls', false);
     }
 }

--- a/test/Writer/XmlWriterTest.php
+++ b/test/Writer/XmlWriterTest.php
@@ -13,12 +13,13 @@ namespace Exporter\Test\Writer;
 
 use Exporter\Writer\XmlWriter;
 
-class XmlWriterTest extends \PHPUnit_Framework_TestCase
+class XmlWriterTest extends AbstractTypedWriterTestCase
 {
     protected $filename;
 
     public function setUp()
     {
+        parent::setUp();
         $this->filename = 'foobar.xml';
 
         if (is_file($this->filename)) {
@@ -28,7 +29,9 @@ class XmlWriterTest extends \PHPUnit_Framework_TestCase
 
     public function tearDown()
     {
-        unlink($this->filename);
+        if (is_file($this->filename)) {
+            unlink($this->filename);
+        }
     }
 
     /**
@@ -69,5 +72,10 @@ class XmlWriterTest extends \PHPUnit_Framework_TestCase
 XML;
 
         $this->assertEquals($expected, file_get_contents($this->filename));
+    }
+
+    protected function getWriter()
+    {
+        return new XmlWriter('/tmp/whatever.xml');
     }
 }


### PR DESCRIPTION
### Changelog

```markdown
### Added
- `MimeTypedWriterInterface` can be implemented to indicate the suitable `Content-Type` header and format for a writer.
```

### Subject

This PR allows us to avoid [this kind of thing](https://github.com/sonata-project/SonataCoreBundle/blob/3.x/Exporter/Exporter.php#L37)

### To do

- [x] Update the documentation
- [x] Add `getFormatName()`