### PR TITLE
Fix wrong PHPDoc type on JsonWriter::$file

### DIFF
--- a/lib/Exporter/Writer/JsonWriter.php
+++ b/lib/Exporter/Writer/JsonWriter.php
@@ -19,7 +19,7 @@ class JsonWriter implements WriterInterface
     protected $filename;
 
     /**
-     * @var string
+     * @var resource
      */
     protected $file;
 


### PR DESCRIPTION
### Subject

It should be a resource, not a string.
