### PR TITLE
Use correct namespace for custom phpunit test cases

### DIFF
--- a/UPGRADE-1.x.md
+++ b/UPGRADE-1.x.md
@@ -1,6 +1,10 @@
 UPGRADE 1.x
 ===========
 
+## Deprectaded AbstractTypedWriterTestCase namespace
+
+The `Test\Writer\AbstractTypedWriterTestCase` class is deprecated. Use `Test\AbstractTypedWriterTestCase` instead.
+
 UPGRADE FROM 1.4 to 1.5
 =======================
 

--- a/src/Test/AbstractTypedWriterTestCase.php
+++ b/src/Test/AbstractTypedWriterTestCase.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Exporter\Test;
+
+/**
+ * @author Grégoire Paris <postmaster@greg0ire.fr>
+ */
+abstract class AbstractTypedWriterTestCase extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var WriterInterface
+     */
+    private $writer;
+
+    protected function setUp()
+    {
+        $this->writer = $this->getWriter();
+    }
+
+    public function testFormatIsString()
+    {
+        $this->assertInternalType('string', $this->writer->getFormat());
+    }
+
+    public function testDefaultMimeTypeIsString()
+    {
+        $this->assertInternalType('string', $this->writer->getDefaultMimeType());
+    }
+
+    /**
+     * Should return a very simple instance of the writer (no need for complex
+     * configuration).
+     *
+     * @return WriterInterface
+     */
+    abstract protected function getWriter();
+}

--- a/test/Writer/AbstractTypedWriterTestCase.php
+++ b/test/Writer/AbstractTypedWriterTestCase.php
@@ -11,38 +11,19 @@
 
 namespace Exporter\Test\Writer;
 
-use Exporter\Writer\WriterInterface;
+use Exporter\Test\AbstractTypedWriterTestCase as BaseTestCase;
+
+@trigger_error(
+    'The '.__NAMESPACE__.'\AbstractTypedWriterTestCase class is deprecated since version 1.x and will be removed in 2.0.'
+    .' Use Exporter\Test\AbstractTypedWriterTestCase instead.',
+    E_USER_DEPRECATED
+);
 
 /**
  * @author Grégoire Paris <postmaster@greg0ire.fr>
+ *
+ * @deprecated Deprecated since version 1.x. Use Exporter\Test\AbstractTypedWriterTestCase instead.
  */
-abstract class AbstractTypedWriterTestCase extends \PHPUnit_Framework_TestCase
+abstract class AbstractTypedWriterTestCase extends BaseTestCase
 {
-    /**
-     * @var WriterInterface
-     */
-    private $writer;
-
-    protected function setUp()
-    {
-        $this->writer = $this->getWriter();
-    }
-
-    public function testFormatIsString()
-    {
-        $this->assertInternalType('string', $this->writer->getFormat());
-    }
-
-    public function testDefaultMimeTypeIsString()
-    {
-        $this->assertInternalType('string', $this->writer->getDefaultMimeType());
-    }
-
-    /**
-     * Should return a very simple instance of the writer (no need for complex
-     * configuration).
-     *
-     * @return WriterInterface
-     */
-    abstract protected function getWriter();
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/exporter/blob/1.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- Deprecate `Test\Writer\AbstractTypedWriterTestCase` in favor of `Test\AbstractTypedWriterTestCase`
```

## Subject

Use the correct namespace for abstract TestCases, so they will be loaded when excluding the tests directory in the (non dev-)autoloader. 

