### PR TITLE
Change namespace to Sonata\Exporter

### DIFF
--- a/UPGRADE-2.0.md
+++ b/UPGRADE-2.0.md
@@ -4,3 +4,7 @@ UPGRADE FROM 1.x to 2.0
 ## Symfony
 
 Symfony support is dropped from 2.3 to 2.7 included.
+
+## Namespace
+
+The namespace was changed from `Exporter` to `Sonata\Expoter`.

--- a/composer.json
+++ b/composer.json
@@ -32,12 +32,12 @@
     },
     "autoload": {
         "psr-4": {
-            "Exporter\\": "src/"
+            "Sonata\\Exporter\\": "src/"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "Exporter\\Test\\": "test/"
+            "Sonata\\Exporter\\Test\\": "test/"
         }
     },
     "extra": {

--- a/src/Exception/InvalidDataFormatException.php
+++ b/src/Exception/InvalidDataFormatException.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Exporter\Exception;
+namespace Sonata\Exporter\Exception;
 
 class InvalidDataFormatException extends \RuntimeException
 {

--- a/src/Exception/InvalidMethodCallException.php
+++ b/src/Exception/InvalidMethodCallException.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Exporter\Exception;
+namespace Sonata\Exporter\Exception;
 
 class InvalidMethodCallException extends \RuntimeException
 {

--- a/src/Handler.php
+++ b/src/Handler.php
@@ -9,10 +9,10 @@
  * file that was distributed with this source code.
  */
 
-namespace Exporter;
+namespace Sonata\Exporter;
 
-use Exporter\Source\SourceIteratorInterface;
-use Exporter\Writer\WriterInterface;
+use Sonata\Exporter\Source\SourceIteratorInterface;
+use Sonata\Exporter\Writer\WriterInterface;
 
 class Handler
 {

--- a/src/Source/AbstractXmlSourceIterator.php
+++ b/src/Source/AbstractXmlSourceIterator.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Exporter\Source;
+namespace Sonata\Exporter\Source;
 
 /**
  * Read data from a Xml file.

--- a/src/Source/ArraySourceIterator.php
+++ b/src/Source/ArraySourceIterator.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Exporter\Source;
+namespace Sonata\Exporter\Source;
 
 class ArraySourceIterator extends IteratorSourceIterator
 {

--- a/src/Source/ChainSourceIterator.php
+++ b/src/Source/ChainSourceIterator.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Exporter\Source;
+namespace Sonata\Exporter\Source;
 
 use ArrayIterator;
 

--- a/src/Source/CsvSourceIterator.php
+++ b/src/Source/CsvSourceIterator.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Exporter\Source;
+namespace Sonata\Exporter\Source;
 
 /**
  * Read data from a csv file.

--- a/src/Source/DoctrineDBALConnectionSourceIterator.php
+++ b/src/Source/DoctrineDBALConnectionSourceIterator.php
@@ -9,11 +9,11 @@
  * file that was distributed with this source code.
  */
 
-namespace Exporter\Source;
+namespace Sonata\Exporter\Source;
 
 use Doctrine\DBAL\Driver\Connection;
 use Doctrine\DBAL\Driver\Statement;
-use Exporter\Exception\InvalidMethodCallException;
+use Sonata\Exporter\Exception\InvalidMethodCallException;
 
 class DoctrineDBALConnectionSourceIterator implements SourceIteratorInterface
 {

--- a/src/Source/DoctrineODMQuerySourceIterator.php
+++ b/src/Source/DoctrineODMQuerySourceIterator.php
@@ -9,11 +9,11 @@
  * file that was distributed with this source code.
  */
 
-namespace Exporter\Source;
+namespace Sonata\Exporter\Source;
 
 use Doctrine\ODM\MongoDB\Query\Query;
 use Doctrine\ORM\Internal\Hydration\IterableResult;
-use Exporter\Exception\InvalidMethodCallException;
+use Sonata\Exporter\Exception\InvalidMethodCallException;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyPath;
 

--- a/src/Source/DoctrineORMQuerySourceIterator.php
+++ b/src/Source/DoctrineORMQuerySourceIterator.php
@@ -9,10 +9,10 @@
  * file that was distributed with this source code.
  */
 
-namespace Exporter\Source;
+namespace Sonata\Exporter\Source;
 
 use Doctrine\ORM\Query;
-use Exporter\Exception\InvalidMethodCallException;
+use Sonata\Exporter\Exception\InvalidMethodCallException;
 use Symfony\Component\PropertyAccess\Exception\UnexpectedTypeException;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyPath;

--- a/src/Source/IteratorCallbackSourceIterator.php
+++ b/src/Source/IteratorCallbackSourceIterator.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Exporter\Source;
+namespace Sonata\Exporter\Source;
 
 /**
  * IteratorCallbackSource is IteratorSource with callback executed each row.

--- a/src/Source/IteratorSourceIterator.php
+++ b/src/Source/IteratorSourceIterator.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Exporter\Source;
+namespace Sonata\Exporter\Source;
 
 /**
  * SourceIterator implementation based on Iterator.

--- a/src/Source/PDOStatementSourceIterator.php
+++ b/src/Source/PDOStatementSourceIterator.php
@@ -9,9 +9,9 @@
  * file that was distributed with this source code.
  */
 
-namespace Exporter\Source;
+namespace Sonata\Exporter\Source;
 
-use Exporter\Exception\InvalidMethodCallException;
+use Sonata\Exporter\Exception\InvalidMethodCallException;
 
 class PDOStatementSourceIterator implements SourceIteratorInterface
 {

--- a/src/Source/PropelCollectionSourceIterator.php
+++ b/src/Source/PropelCollectionSourceIterator.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Exporter\Source;
+namespace Sonata\Exporter\Source;
 
 use PropelCollection;
 use Symfony\Component\PropertyAccess\PropertyAccess;

--- a/src/Source/SourceIteratorInterface.php
+++ b/src/Source/SourceIteratorInterface.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Exporter\Source;
+namespace Sonata\Exporter\Source;
 
 interface SourceIteratorInterface extends \Iterator
 {

--- a/src/Source/SymfonySitemapSourceIterator.php
+++ b/src/Source/SymfonySitemapSourceIterator.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Exporter\Source;
+namespace Sonata\Exporter\Source;
 
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\RouterInterface;

--- a/src/Source/XmlExcelSourceIterator.php
+++ b/src/Source/XmlExcelSourceIterator.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Exporter\Source;
+namespace Sonata\Exporter\Source;
 
 /**
  * Read data from a Xml Excel file.

--- a/src/Source/XmlSourceIterator.php
+++ b/src/Source/XmlSourceIterator.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Exporter\Source;
+namespace Sonata\Exporter\Source;
 
 /**
  * Read data from a Xml file.

--- a/src/Writer/CsvWriter.php
+++ b/src/Writer/CsvWriter.php
@@ -9,9 +9,9 @@
  * file that was distributed with this source code.
  */
 
-namespace Exporter\Writer;
+namespace Sonata\Exporter\Writer;
 
-use Exporter\Exception\InvalidDataFormatException;
+use Sonata\Exporter\Exception\InvalidDataFormatException;
 
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>

--- a/src/Writer/FormattedBoolWriter.php
+++ b/src/Writer/FormattedBoolWriter.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Exporter\Writer;
+namespace Sonata\Exporter\Writer;
 
 /**
  * Format boolean before use another writer.

--- a/src/Writer/GsaFeedWriter.php
+++ b/src/Writer/GsaFeedWriter.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Exporter\Writer;
+namespace Sonata\Exporter\Writer;
 
 /**
  * Generates a GSA feed.

--- a/src/Writer/InMemoryWriter.php
+++ b/src/Writer/InMemoryWriter.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Exporter\Writer;
+namespace Sonata\Exporter\Writer;
 
 class InMemoryWriter implements WriterInterface
 {

--- a/src/Writer/JsonWriter.php
+++ b/src/Writer/JsonWriter.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Exporter\Writer;
+namespace Sonata\Exporter\Writer;
 
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>

--- a/src/Writer/SitemapWriter.php
+++ b/src/Writer/SitemapWriter.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Exporter\Writer;
+namespace Sonata\Exporter\Writer;
 
 /**
  * Generates a sitemap site from.

--- a/src/Writer/TypedWriterInterface.php
+++ b/src/Writer/TypedWriterInterface.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Exporter\Writer;
+namespace Sonata\Exporter\Writer;
 
 /**
  * @author Grégoire Paris <postmaster@greg0ire.fr>

--- a/src/Writer/WriterInterface.php
+++ b/src/Writer/WriterInterface.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Exporter\Writer;
+namespace Sonata\Exporter\Writer;
 
 interface WriterInterface
 {

--- a/src/Writer/XlsWriter.php
+++ b/src/Writer/XlsWriter.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Exporter\Writer;
+namespace Sonata\Exporter\Writer;
 
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>

--- a/src/Writer/XmlExcelWriter.php
+++ b/src/Writer/XmlExcelWriter.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Exporter\Writer;
+namespace Sonata\Exporter\Writer;
 
 /**
  * Generate a Xml Excel file.

--- a/src/Writer/XmlWriter.php
+++ b/src/Writer/XmlWriter.php
@@ -9,9 +9,9 @@
  * file that was distributed with this source code.
  */
 
-namespace Exporter\Writer;
+namespace Sonata\Exporter\Writer;
 
-use Exporter\Exception\InvalidDataFormatException;
+use Sonata\Exporter\Exception\InvalidDataFormatException;
 
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>

--- a/test/HandlerTest.php
+++ b/test/HandlerTest.php
@@ -9,16 +9,16 @@
  * file that was distributed with this source code.
  */
 
-namespace Exporter\Test;
+namespace Sonata\Exporter\Test;
 
-use Exporter\Handler;
+use Sonata\Exporter\Handler;
 
 class HandlerTest extends \PHPUnit_Framework_TestCase
 {
     public function testHandler()
     {
-        $source = $this->getMock('Exporter\Source\SourceIteratorInterface');
-        $writer = $this->getMock('Exporter\Writer\WriterInterface');
+        $source = $this->getMock('Sonata\Exporter\Source\SourceIteratorInterface');
+        $writer = $this->getMock('Sonata\Exporter\Writer\WriterInterface');
         $writer->expects($this->once())->method('open');
         $writer->expects($this->once())->method('close');
 

--- a/test/Source/ArraySourceIteratorTest.php
+++ b/test/Source/ArraySourceIteratorTest.php
@@ -9,9 +9,9 @@
  * file that was distributed with this source code.
  */
 
-namespace Exporter\Test\Source;
+namespace Sonata\Exporter\Test\Source;
 
-use Exporter\Source\ArraySourceIterator;
+use Sonata\Exporter\Source\ArraySourceIterator;
 
 class ArraySourceIteratorTest extends \PHPUnit_Framework_TestCase
 {

--- a/test/Source/ChainSourceIteratorTest.php
+++ b/test/Source/ChainSourceIteratorTest.php
@@ -9,15 +9,15 @@
  * file that was distributed with this source code.
  */
 
-namespace Exporter\Test\Source;
+namespace Sonata\Exporter\Test\Source;
 
-use Exporter\Source\ChainSourceIterator;
+use Sonata\Exporter\Source\ChainSourceIterator;
 
 class ChainSourceIteratorTest extends \PHPUnit_Framework_TestCase
 {
     public function testIterator()
     {
-        $source = $this->getMock('Exporter\Source\SourceIteratorInterface');
+        $source = $this->getMock('Sonata\Exporter\Source\SourceIteratorInterface');
 
         $iterator = new ChainSourceIterator(array($source));
 

--- a/test/Source/CsvSourceIteratorTest.php
+++ b/test/Source/CsvSourceIteratorTest.php
@@ -9,9 +9,9 @@
  * file that was distributed with this source code.
  */
 
-namespace Exporter\Test\Source;
+namespace Sonata\Exporter\Test\Source;
 
-use Exporter\Source\CsvSourceIterator;
+use Sonata\Exporter\Source\CsvSourceIterator;
 
 class CsvSourceIteratorTest extends \PHPUnit_Framework_TestCase
 {

--- a/test/Source/IteratorCallbackSourceIteratorTest.php
+++ b/test/Source/IteratorCallbackSourceIteratorTest.php
@@ -9,9 +9,9 @@
  * file that was distributed with this source code.
  */
 
-namespace Exporter\Test\Source;
+namespace Sonata\Exporter\Test\Source;
 
-use Exporter\Source\IteratorCallbackSourceIterator;
+use Sonata\Exporter\Source\IteratorCallbackSourceIterator;
 
 class IteratorCallbackSourceIteratorTest extends \PHPUnit_Framework_TestCase
 {
@@ -42,7 +42,7 @@ class IteratorCallbackSourceIteratorTest extends \PHPUnit_Framework_TestCase
 
     public function testExtends()
     {
-        $this->assertInstanceOf('Exporter\Source\IteratorSourceIterator', $this->sourceIterator);
+        $this->assertInstanceOf('Sonata\Exporter\Source\IteratorSourceIterator', $this->sourceIterator);
     }
 
     public function testGetIterator()

--- a/test/Source/IteratorSourceIteratorTest.php
+++ b/test/Source/IteratorSourceIteratorTest.php
@@ -9,9 +9,9 @@
  * file that was distributed with this source code.
  */
 
-namespace Exporter\Test\Source;
+namespace Sonata\Exporter\Test\Source;
 
-use Exporter\Source\IteratorSourceIterator;
+use Sonata\Exporter\Source\IteratorSourceIterator;
 
 class IteratorSourceIteratorTest extends \PHPUnit_Framework_TestCase
 {

--- a/test/Source/PDOStatementSourceIteratorTest.php
+++ b/test/Source/PDOStatementSourceIteratorTest.php
@@ -9,9 +9,9 @@
  * file that was distributed with this source code.
  */
 
-namespace Exporter\Test\Source;
+namespace Sonata\Exporter\Test\Source;
 
-use Exporter\Source\PDOStatementSourceIterator;
+use Sonata\Exporter\Source\PDOStatementSourceIterator;
 
 class PDOStatementSourceIteratorTest extends \PHPUnit_Framework_TestCase
 {

--- a/test/Source/PropelCollectionSourceIteratorTest.php
+++ b/test/Source/PropelCollectionSourceIteratorTest.php
@@ -9,9 +9,9 @@
  * file that was distributed with this source code.
  */
 
-namespace Exporter\Test\Source;
+namespace Sonata\Exporter\Test\Source;
 
-use Exporter\Source\PropelCollectionSourceIterator;
+use Sonata\Exporter\Source\PropelCollectionSourceIterator;
 
 /**
  * Tests the PropelCollectionSourceIterator class.

--- a/test/Source/XmlExcelSourceIteratorTest.php
+++ b/test/Source/XmlExcelSourceIteratorTest.php
@@ -9,9 +9,9 @@
  * file that was distributed with this source code.
  */
 
-namespace Exporter\Test\Source;
+namespace Sonata\Exporter\Test\Source;
 
-use Exporter\Source\XmlExcelSourceIterator;
+use Sonata\Exporter\Source\XmlExcelSourceIterator;
 
 class XmlExcelSourceIteratorTest extends \PHPUnit_Framework_TestCase
 {

--- a/test/Source/XmlSourceIteratorTest.php
+++ b/test/Source/XmlSourceIteratorTest.php
@@ -9,9 +9,9 @@
  * file that was distributed with this source code.
  */
 
-namespace Exporter\Test\Source;
+namespace Sonata\Exporter\Test\Source;
 
-use Exporter\Source\XmlSourceIterator;
+use Sonata\Exporter\Source\XmlSourceIterator;
 
 class XmlSourceIteratorTest extends \PHPUnit_Framework_TestCase
 {

--- a/test/Writer/AbstractTypedWriterTestCase.php
+++ b/test/Writer/AbstractTypedWriterTestCase.php
@@ -9,9 +9,9 @@
  * file that was distributed with this source code.
  */
 
-namespace Exporter\Test\Writer;
+namespace Sonata\Exporter\Test\Writer;
 
-use Exporter\Writer\WriterInterface;
+use Sonata\Exporter\Writer\WriterInterface;
 
 /**
  * @author Grégoire Paris <postmaster@greg0ire.fr>

--- a/test/Writer/CsvWriterTest.php
+++ b/test/Writer/CsvWriterTest.php
@@ -9,9 +9,9 @@
  * file that was distributed with this source code.
  */
 
-namespace Exporter\Test\Writer;
+namespace Sonata\Exporter\Test\Writer;
 
-use Exporter\Writer\CsvWriter;
+use Sonata\Exporter\Writer\CsvWriter;
 
 class CsvWriterTest extends AbstractTypedWriterTestCase
 {
@@ -35,7 +35,7 @@ class CsvWriterTest extends AbstractTypedWriterTestCase
     }
 
     /**
-     * @expectedException \Exporter\Exception\InvalidDataFormatException
+     * @expectedException \Sonata\Exporter\Exception\InvalidDataFormatException
      */
     public function testInvalidDataFormat()
     {

--- a/test/Writer/FormattedBoolWriterTest.php
+++ b/test/Writer/FormattedBoolWriterTest.php
@@ -9,9 +9,9 @@
  * file that was distributed with this source code.
  */
 
-namespace Exporter\Test\Writer;
+namespace Sonata\Exporter\Test\Writer;
 
-use Exporter\Writer\FormattedBoolWriter;
+use Sonata\Exporter\Writer\FormattedBoolWriter;
 
 /**
  * Format boolean before use another writer.
@@ -40,7 +40,7 @@ class FormattedBoolWriterTest extends \PHPUnit_Framework_TestCase
     {
         $data = array('john', 'doe', false, true);
         $expected = array('john', 'doe', 'no', 'yes');
-        $mock = $this->getMockBuilder('Exporter\Writer\XlsWriter')
+        $mock = $this->getMockBuilder('Sonata\Exporter\Writer\XlsWriter')
                        ->setConstructorArgs(array('formatedbool.xls', false))
                        ->getMock();
         $mock->expects($this->any())

--- a/test/Writer/GsaFeedWriterTest.php
+++ b/test/Writer/GsaFeedWriterTest.php
@@ -9,9 +9,9 @@
  * file that was distributed with this source code.
  */
 
-namespace Exporter\Test\Writer;
+namespace Sonata\Exporter\Test\Writer;
 
-use Exporter\Writer\GsaFeedWriter;
+use Sonata\Exporter\Writer\GsaFeedWriter;
 
 /**
  * Tests the GSA feed writer class.

--- a/test/Writer/JsonWriterTest.php
+++ b/test/Writer/JsonWriterTest.php
@@ -9,9 +9,9 @@
  * file that was distributed with this source code.
  */
 
-namespace Exporter\Test\Writer;
+namespace Sonata\Exporter\Test\Writer;
 
-use Exporter\Writer\JsonWriter;
+use Sonata\Exporter\Writer\JsonWriter;
 
 class JsonWriterTest extends AbstractTypedWriterTestCase
 {

--- a/test/Writer/SitemapWriterTest.php
+++ b/test/Writer/SitemapWriterTest.php
@@ -9,10 +9,10 @@
  * file that was distributed with this source code.
  */
 
-namespace Exporter\Test\Writer;
+namespace Sonata\Exporter\Test\Writer;
 
-use Exporter\Writer\SitemapWriter;
 use SimpleXMLElement;
+use Sonata\Exporter\Writer\SitemapWriter;
 
 class SitemapWriterTest extends \PHPUnit_Framework_TestCase
 {

--- a/test/Writer/XlsWriterTest.php
+++ b/test/Writer/XlsWriterTest.php
@@ -9,9 +9,9 @@
  * file that was distributed with this source code.
  */
 
-namespace Exporter\Test\Writer;
+namespace Sonata\Exporter\Test\Writer;
 
-use Exporter\Writer\XlsWriter;
+use Sonata\Exporter\Writer\XlsWriter;
 
 class XlsWriterTest extends AbstractTypedWriterTestCase
 {

--- a/test/Writer/XmlExcelWriterTest.php
+++ b/test/Writer/XmlExcelWriterTest.php
@@ -9,9 +9,9 @@
  * file that was distributed with this source code.
  */
 
-namespace Exporter\Test\Writer;
+namespace Sonata\Exporter\Test\Writer;
 
-use Exporter\Writer\XmlExcelWriter;
+use Sonata\Exporter\Writer\XmlExcelWriter;
 
 class XmlExcelWriterTest extends \PHPUnit_Framework_TestCase
 {

--- a/test/Writer/XmlWriterTest.php
+++ b/test/Writer/XmlWriterTest.php
@@ -9,9 +9,9 @@
  * file that was distributed with this source code.
  */
 
-namespace Exporter\Test\Writer;
+namespace Sonata\Exporter\Test\Writer;
 
-use Exporter\Writer\XmlWriter;
+use Sonata\Exporter\Writer\XmlWriter;
 
 class XmlWriterTest extends AbstractTypedWriterTestCase
 {


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/exporter/blob/1.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is a major change.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Fixes #119

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Changed the namespace from `Expoter` to `Sonata\Exporter`
```

## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

- [X] Add an upgrade note

## Subject

Adds the `Sonata` vendor prefix to the namespace.