### PR TITLE
Use recommended AbstractTypedWriterTestCase class in tests

### DIFF
--- a/test/Writer/CsvWriterTest.php
+++ b/test/Writer/CsvWriterTest.php
@@ -11,6 +11,7 @@
 
 namespace Exporter\Test\Writer;
 
+use Exporter\Test\AbstractTypedWriterTestCase;
 use Exporter\Writer\CsvWriter;
 
 class CsvWriterTest extends AbstractTypedWriterTestCase

--- a/test/Writer/JsonWriterTest.php
+++ b/test/Writer/JsonWriterTest.php
@@ -11,6 +11,7 @@
 
 namespace Exporter\Test\Writer;
 
+use Exporter\Test\AbstractTypedWriterTestCase;
 use Exporter\Writer\JsonWriter;
 
 class JsonWriterTest extends AbstractTypedWriterTestCase

--- a/test/Writer/XlsWriterTest.php
+++ b/test/Writer/XlsWriterTest.php
@@ -11,6 +11,7 @@
 
 namespace Exporter\Test\Writer;
 
+use Exporter\Test\AbstractTypedWriterTestCase;
 use Exporter\Writer\XlsWriter;
 
 class XlsWriterTest extends AbstractTypedWriterTestCase

--- a/test/Writer/XmlWriterTest.php
+++ b/test/Writer/XmlWriterTest.php
@@ -11,6 +11,7 @@
 
 namespace Exporter\Test\Writer;
 
+use Exporter\Test\AbstractTypedWriterTestCase;
 use Exporter\Writer\XmlWriter;
 
 class XmlWriterTest extends AbstractTypedWriterTestCase


### PR DESCRIPTION
I am targetting this branch, because this is BC

## Changelog
```markdown
### Changed
- Use recommended `AbstractTypedWriterTestCase` class in tests
```

## Subject
Since deprecation of previous `AbstractTypedWriterTestCase` class, exporter unit tests should now use recommended class.

