### PR TITLE
Add exporter service

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,11 @@
     "require-dev": {
         "doctrine/dbal": "^2.2",
         "doctrine/orm": "^2.2",
+        "matthiasnoback/symfony-config-test": "^1.2.1 || ^2.0",
+        "matthiasnoback/symfony-dependency-injection-test": "^0.7.6 || ^1.0",
+        "symfony/dependency-injection": "^2.3 || ^3.0",
+        "symfony/http-foundation": "^2.3 || ^3.0",
+        "symfony/http-kernel": "^2.3 || ^3.0",
         "symfony/routing": "^2.3 || ^3.0",
         "symfony/property-access": "^2.3 || ^3.0",
         "symfony/phpunit-bridge": "^2.7 || ^3.0",

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,5 +14,4 @@ Summary
     Installation <reference/installation>
     Sources <reference/sources>
     Outputs <reference/outputs>
-
-
+    Symfony integration <reference/symfony>

--- a/docs/reference/symfony.rst
+++ b/docs/reference/symfony.rst
@@ -1,0 +1,99 @@
+========================
+Integration with Symfony
+========================
+
+This library provides a Symfony bundle that you can register in the kernel of your application.
+Doing so will make a ``sonata.exporter.exporter`` service available.
+This service is able to build a streamed response directly usable in a Symfony controller
+from a format, a filename, and a source.
+
+Registering the bundle
+----------------------
+
+.. code-block:: php
+
+    // app/AppKernel.php
+
+    public function registerBundles()
+    {
+        $bundles = array(
+            // …
+            new Exporter\Bridge\Symfony\Bundle\SonataExporterBundle();
+        );
+
+        // …
+
+        return $bundles;
+    }
+
+
+The default writers
+-------------------
+
+Under the hood, the exporter uses one service for each available format.
+Each service has its own parameters, documented below.
+
+Each service parameter has a configuration countepart:
+
+.. code-block:: yaml
+
+    sonata_exporter:
+        writers:
+            some_format:
+                some_setting: some_value
+
+The CSV writer service
+~~~~~~~~~~~~~~~~~~~~~~
+This service can be configured throught the following parameters:
+
+* ``sonata.exporter.writer.csv.filename``: defaults to ``php://output``
+* ``sonata.exporter.writer.csv.delimiter``: defaults to ``,``
+* ``sonata.exporter.writer.csv.enclosure``: defaults to ``"``
+* ``sonata.exporter.writer.csv.escape``: defaults to ``\\``
+* ``sonata.exporter.writer.csv.show_headers``: defaults to ``true``
+* ``sonata.exporter.writer.csv.with_bom``: defaults to ``false``
+
+The JSON writer service
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Only the filename may be configured for this service:
+``sonata.exporter.writer.json.filename``: defaults to ``php://output``
+
+The XLS writer service
+~~~~~~~~~~~~~~~~~~~~~~~
+
+This service can be configured throught the following parameters:
+
+* ``sonata.exporter.writer.xls.filename``: defaults to ``php://output``
+* ``sonata.exporter.writer.xls.show_headers``: defaults to ``true``
+
+The XML writer service
+~~~~~~~~~~~~~~~~~~~~~~~
+
+This service can be configured throught the following parameters:
+
+* ``sonata.exporter.writer.xml.filename``: defaults to ``php://output``
+* ``sonata.exporter.writer.xml.show_headers``: defaults to ``true``
+* ``sonata.exporter.writer.xml.main_element``: defaults to ``datas``
+* ``sonata.exporter.writer.xml.child_element``: defaults to ``data``
+
+Adding a custom writer to the list
+----------------------------------
+
+If you want to add a custom writer to the list of writers supported by the exporter,
+you simply need to tag your service,
+which must implement ``Exporter\Writer\TypedWriterInterface``,
+with the ``sonata.exporter.writer`` tag.
+
+Configuring the default writers
+-------------------------------
+
+The default writers list can be altered through configuration:
+
+.. code-block:: yaml
+
+    sonata_exporter:
+        exporter:
+            default_writers:
+                - csv
+                - json

--- a/src/Bridge/Symfony/Bundle/SonataExporterBundle.php
+++ b/src/Bridge/Symfony/Bundle/SonataExporterBundle.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Exporter\Bridge\Symfony\Bundle;
+
+use Exporter\Bridge\Symfony\DependencyInjection\Compiler\ExporterCompilerPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+final class SonataExporterBundle extends Bundle
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function build(ContainerBuilder $container)
+    {
+        $container->addCompilerPass(new ExporterCompilerPass());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getContainerExtensionClass()
+    {
+        return 'Exporter\Bridge\Symfony\DependencyInjection\SonataExporterExtension';
+    }
+}

--- a/src/Bridge/Symfony/DependencyInjection/Compiler/ExporterCompilerPass.php
+++ b/src/Bridge/Symfony/DependencyInjection/Compiler/ExporterCompilerPass.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Exporter\Bridge\Symfony\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * @author Grégoire Paris <postmaster@greg0ire.fr>
+ */
+final class ExporterCompilerPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->has('sonata.exporter.exporter')) {
+            return;
+        }
+
+        $definition = $container->findDefinition('sonata.exporter.exporter');
+        $writers = $container->findTaggedServiceIds('sonata.exporter.writer');
+
+        foreach (array_keys($writers) as $id) {
+            $definition->addMethodCall('addWriter', array(new Reference($id)));
+        }
+    }
+}

--- a/src/Bridge/Symfony/DependencyInjection/Configuration.php
+++ b/src/Bridge/Symfony/DependencyInjection/Configuration.php
@@ -1,0 +1,125 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Exporter\Bridge\Symfony\DependencyInjection;
+
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+/**
+ * This is the class that validates and merges configuration from your app/config files.
+ *
+ * @author Grégoire Paris <postmaster@greg0ire.fr>
+ */
+final class Configuration implements ConfigurationInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getConfigTreeBuilder()
+    {
+        $treeBuilder = new TreeBuilder();
+        $rootNode = $treeBuilder->root('sonata_exporter');
+
+        $rootNode
+            ->children()
+                ->arrayNode('exporter')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->arrayNode('default_writers')
+                            ->defaultValue(array('csv', 'json', 'xls', 'xml'))
+                            ->prototype('scalar')->end()
+                        ->end()
+                    ->end()
+                ->end()
+                ->arrayNode('writers')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->arrayNode('csv')
+                            ->addDefaultsIfNotSet()
+                            ->children()
+                                ->scalarNode('filename')
+                                    ->defaultValue('php://output')
+                                    ->info('path to the output file')
+                                ->end()
+                                ->scalarNode('delimiter')
+                                    ->defaultValue(',')
+                                    ->info('delimits csv values')
+                                ->end()
+                                ->scalarNode('enclosure')
+                                    ->defaultValue('"')
+                                    ->info('will be used when a value contains the delimiter')
+                                ->end()
+                                ->scalarNode('escape')
+                                    ->defaultValue('\\')
+                                    ->info('will be used when a value contains the enclosure')
+                                ->end()
+                                ->booleanNode('show_headers')
+                                    ->defaultValue(true)
+                                    ->info('add column names as the first line')
+                                ->end()
+                                ->booleanNode('with_bom')
+                                    ->defaultValue(false)
+                                    ->info('include the byte order mark')
+                                ->end()
+                            ->end()
+                        ->end()
+                        ->arrayNode('json')
+                            ->addDefaultsIfNotSet()
+                            ->children()
+                                ->scalarNode('filename')
+                                    ->defaultValue('php://output')
+                                    ->info('path to the output file')
+                                ->end()
+                            ->end()
+                        ->end()
+                        ->arrayNode('xls')
+                            ->addDefaultsIfNotSet()
+                            ->children()
+                                ->scalarNode('filename')
+                                    ->defaultValue('php://output')
+                                    ->info('path to the output file')
+                                ->end()
+                                ->booleanNode('show_headers')
+                                    ->defaultValue(true)
+                                    ->info('add column names as the first line')
+                                ->end()
+                            ->end()
+                        ->end()
+                        ->arrayNode('xml')
+                            ->addDefaultsIfNotSet()
+                            ->children()
+                                ->scalarNode('filename')
+                                    ->defaultValue('php://output')
+                                    ->info('path to the output file')
+                                ->end()
+                                ->booleanNode('show_headers')
+                                    ->defaultValue(true)
+                                    ->info('add column names as the first line')
+                                ->end()
+                                ->scalarNode('main_element')
+                                    ->defaultValue('datas')
+                                    ->info('name of the wrapping element')
+                                ->end()
+                                ->scalarNode('child_element')
+                                    ->defaultValue('data')
+                                    ->info('name of elements corresponding to rows')
+                                ->end()
+                            ->end()
+                        ->end()
+                    ->end()
+                ->end()
+            ->end()
+        ;
+
+        return $treeBuilder;
+    }
+}

--- a/src/Bridge/Symfony/DependencyInjection/SonataExporterExtension.php
+++ b/src/Bridge/Symfony/DependencyInjection/SonataExporterExtension.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Exporter\Bridge\Symfony\DependencyInjection;
+
+use Symfony\Component\Config\Definition\Processor;
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
+use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+
+/**
+ * @author Grégoire Paris <postmaster@greg0ire.fr>
+ */
+final class SonataExporterExtension extends Extension
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function load(array $configs, ContainerBuilder $container)
+    {
+        $processor = new Processor();
+        $configuration = new Configuration();
+        $config = $processor->processConfiguration($configuration, $configs);
+
+        $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader->load('services.xml');
+
+        $this->configureExporter($container, $config['exporter']);
+        $this->configureWriters($container, $config['writers']);
+    }
+
+    private function configureExporter(ContainerBuilder $container, array $config)
+    {
+        foreach (array('csv', 'json', 'xls', 'xml') as $format) {
+            if (in_array($format, $config['default_writers'])) {
+                $container->getDefinition('sonata.exporter.writer.'.$format)->addTag(
+                    'sonata.exporter.writer'
+                );
+            }
+        }
+    }
+
+    private function configureWriters(ContainerBuilder $container, array $config)
+    {
+        foreach ($config as $format => $settings) {
+            foreach ($settings as $key => $value) {
+                $container->setParameter(sprintf(
+                    'sonata.exporter.writer.%s.%s',
+                    $format,
+                    $key
+                ), $value);
+            }
+        }
+    }
+}

--- a/src/Bridge/Symfony/Resources/config/services.xml
+++ b/src/Bridge/Symfony/Resources/config/services.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <service id="sonata.exporter.writer.csv" class="Exporter\Writer\CsvWriter" public="false">
+            <argument>%sonata.exporter.writer.csv.filename%</argument>
+            <argument>%sonata.exporter.writer.csv.delimiter%</argument>
+            <argument>%sonata.exporter.writer.csv.enclosure%</argument>
+            <argument>%sonata.exporter.writer.csv.escape%</argument>
+            <argument>%sonata.exporter.writer.csv.show_headers%</argument>
+            <argument>%sonata.exporter.writer.csv.with_bom%</argument>
+        </service>
+        <service id="sonata.exporter.writer.json" class="Exporter\Writer\JsonWriter" public="false">
+            <argument>%sonata.exporter.writer.json.filename%</argument>
+        </service>
+        <service id="sonata.exporter.writer.xls" class="Exporter\Writer\XlsWriter" public="false">
+            <argument>%sonata.exporter.writer.xls.filename%</argument>
+            <argument>%sonata.exporter.writer.xls.show_headers%</argument>
+        </service>
+        <service id="sonata.exporter.writer.xml" class="Exporter\Writer\XmlWriter" public="false">
+            <argument>%sonata.exporter.writer.xml.filename%</argument>
+            <argument>%sonata.exporter.writer.xml.main_element%</argument>
+            <argument>%sonata.exporter.writer.xml.child_element%</argument>
+        </service>
+        <service id="sonata.exporter.exporter" class="Exporter\Exporter"/>
+    </services>
+</container>

--- a/src/Exporter.php
+++ b/src/Exporter.php
@@ -1,0 +1,83 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Exporter;
+
+use Exporter\Source\SourceIteratorInterface;
+use Exporter\Writer\TypedWriterInterface;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+/**
+ * @author Grégoire Paris <postmaster@greg0ire.fr>
+ */
+final class Exporter
+{
+    /**
+     * @var TypedWriterInterface[]
+     */
+    private $writers;
+
+    /**
+     * @param TypedWriterInterface[] $writers an array of allowed typed writers, indexed by format name
+     */
+    public function __construct(array $writers = array())
+    {
+        $this->writers = array();
+
+        foreach ($writers as $writer) {
+            $this->addWriter($writer);
+        }
+    }
+
+    /**
+     * @throws \RuntimeException
+     *
+     * @param string                  $format
+     * @param string                  $filename
+     * @param SourceIteratorInterface $source
+     *
+     * @return StreamedResponse
+     */
+    public function getResponse($format, $filename, SourceIteratorInterface $source)
+    {
+        if (!array_key_exists($format, $this->writers)) {
+            throw new \RuntimeException(sprintf(
+                'Invalid "%s" format, supported formats are : "%s"',
+                $format,
+                implode(', ', array_keys($this->writers))
+            ));
+        }
+        $writer = $this->writers[$format];
+
+        $callback = function () use ($source, $writer) {
+            $handler = \Exporter\Handler::create($source, $writer);
+            $handler->export();
+        };
+
+        $headers = array(
+            'Content-Disposition' => sprintf('attachment; filename="%s"', $filename),
+        );
+
+        $headers['Content-Type'] = $writer->getDefaultMimeType();
+
+        return new StreamedResponse($callback, 200, $headers);
+    }
+
+    /**
+     * The main benefit of this method is the type hinting.
+     *
+     * @param TypedWriterInterface $writer a possible writer for exporting data
+     */
+    private function addWriter(TypedWriterInterface $writer)
+    {
+        $this->writers[$writer->getFormat()] = $writer;
+    }
+}

--- a/test/Bridge/Symfony/DependencyInjection/ConfigurationTest.php
+++ b/test/Bridge/Symfony/DependencyInjection/ConfigurationTest.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Exporter\Tests\Bridge\Symfony\DependencyInjection;
+
+use Exporter\Bridge\Symfony\DependencyInjection\Configuration;
+use Matthias\SymfonyConfigTest\PhpUnit\AbstractConfigurationTestCase;
+
+class ConfigurationTest extends AbstractConfigurationTestCase
+{
+    public function getConfiguration()
+    {
+        return new Configuration();
+    }
+
+    public function testDefault()
+    {
+        $this->assertProcessedConfigurationEquals(array(
+            array(),
+        ), array(
+            'exporter' => array('default_writers' => array(
+                'csv', 'json', 'xls', 'xml',
+            )),
+            'writers' => array(
+                'csv' => array(
+                    'filename' => 'php://output',
+                    'delimiter' => ',',
+                    'enclosure' => '"',
+                    'escape' => '\\',
+                    'show_headers' => true,
+                    'with_bom' => false,
+                ),
+                'json' => array(
+                    'filename' => 'php://output',
+                ),
+                'xls' => array(
+                    'filename' => 'php://output',
+                    'show_headers' => true,
+                ),
+                'xml' => array(
+                    'filename' => 'php://output',
+                    'show_headers' => true,
+                    'main_element' => 'datas',
+                    'child_element' => 'data',
+                ),
+            ),
+        ));
+    }
+}

--- a/test/Bridge/Symfony/DependencyInjection/ExporterCompilerPassTest.php
+++ b/test/Bridge/Symfony/DependencyInjection/ExporterCompilerPassTest.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Exporter\Tests\Bridge\Symfony\DependencyInjection\Compiler;
+
+use Exporter\Bridge\Symfony\DependencyInjection\Compiler\ExporterCompilerPass;
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+class ExporterCompilerPassTest extends AbstractCompilerPassTestCase
+{
+    public function testWritersAreAddedToTheExporter()
+    {
+        $exporter = new Definition();
+        $this->setDefinition('sonata.exporter.exporter', $exporter);
+
+        $writer = new Definition();
+        $writer->addTag('sonata.exporter.writer');
+        $this->setDefinition('foo_writer', $writer);
+
+        $this->compile();
+        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
+            'sonata.exporter.exporter',
+            'addWriter',
+            array(new Reference('foo_writer'))
+        );
+    }
+
+    protected function registerCompilerPass(ContainerBuilder $container)
+    {
+        $container->addCompilerPass(new ExporterCompilerPass());
+    }
+}

--- a/test/Bridge/Symfony/DependencyInjection/SonataExporterExtensionTest.php
+++ b/test/Bridge/Symfony/DependencyInjection/SonataExporterExtensionTest.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Exporter\Tests\Bridge\Symfony\DependencyInjection;
+
+use Exporter\Bridge\Symfony\DependencyInjection\SonataExporterExtension;
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
+
+class SonataExporterExtensionTest extends AbstractExtensionTestCase
+{
+    public function testExporterServiceIsPresent()
+    {
+        $this->load();
+        $this->assertContainerBuilderHasService('sonata.exporter.exporter');
+    }
+
+    public function testServiceParametersArePresent()
+    {
+        $this->load();
+        foreach (array(
+            'sonata.exporter.writer.csv.filename',
+            'sonata.exporter.writer.csv.delimiter',
+            'sonata.exporter.writer.csv.enclosure',
+            'sonata.exporter.writer.csv.escape',
+            'sonata.exporter.writer.csv.show_headers',
+            'sonata.exporter.writer.csv.with_bom',
+            'sonata.exporter.writer.json.filename',
+            'sonata.exporter.writer.xls.filename',
+            'sonata.exporter.writer.xls.show_headers',
+            'sonata.exporter.writer.xml.filename',
+            'sonata.exporter.writer.xml.main_element',
+            'sonata.exporter.writer.xml.child_element',
+        ) as $parameter) {
+            $this->assertContainerBuilderHasParameter($parameter);
+        }
+    }
+
+    protected function getContainerExtensions()
+    {
+        return array(
+            new SonataExporterExtension(),
+        );
+    }
+}

--- a/test/ExporterTest.php
+++ b/test/ExporterTest.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Exporter\Tests;
+
+use Exporter\Exporter;
+use Exporter\Source\ArraySourceIterator;
+use Exporter\Writer\CsvWriter;
+use Exporter\Writer\JsonWriter;
+use Exporter\Writer\XlsWriter;
+use Exporter\Writer\XmlWriter;
+
+class ExporterTest extends \PHPUnit_Framework_TestCase
+{
+    public function testFilter()
+    {
+        $this->setExpectedException('RuntimeException', 'Invalid "foo" format');
+        $source = $this->getMock('Exporter\Source\SourceIteratorInterface');
+        $writer = $this->getMock('Exporter\Writer\TypedWriterInterface');
+
+        $exporter = new Exporter(array($writer));
+        $exporter->getResponse('foo', 'foo', $source);
+    }
+
+    public function testConstructorRejectsNonTypedWriters()
+    {
+        $this->setExpectedException(
+            version_compare(PHP_VERSION, '7.0.0', '<') ? 'PHPUnit_Framework_Error' : 'TypeError',
+            'must implement interface'
+        );
+        new Exporter(array('Not even an object'));
+    }
+
+    /**
+     * @dataProvider getGetResponseTests
+     */
+    public function testGetResponse($format, $filename, $contentType)
+    {
+        $source = new ArraySourceIterator(array(
+            array('foo' => 'bar'),
+        ));
+        $writer = $this->getMock('Exporter\Writer\TypedWriterInterface');
+        $writer->expects($this->any())
+            ->method('getFormat')
+            ->willReturn('made-up');
+        $writer->expects($this->any())
+            ->method('getDefaultMimeType')
+            ->willReturn('application/made-up');
+
+        $exporter = new Exporter(array(
+            'csv' => new CsvWriter('php://output', ',', '"', '', true, true),
+            'json' => new JsonWriter('php://output'),
+            'xls' => new XlsWriter('php://output'),
+            'xml' => new XmlWriter('php://output'),
+            'made-up' => $writer,
+        ));
+        $response = $exporter->getResponse($format, $filename, $source);
+
+        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $response);
+        $this->assertSame($contentType, $response->headers->get('Content-Type'));
+        $this->assertSame('attachment; filename="'.$filename.'"', $response->headers->get('Content-Disposition'));
+    }
+
+    public function getGetResponseTests()
+    {
+        return array(
+            array('json', 'foo.json', 'application/json'),
+            array('xml', 'foo.xml', 'text/xml'),
+            array('xls', 'foo.xls', 'application/vnd.ms-excel'),
+            array('csv', 'foo.csv', 'text/csv'),
+            array('made-up', 'foo.made-up', 'application/made-up'),
+        );
+    }
+}


### PR DESCRIPTION
I am targetting this branch, because this is a fully BC feature

Closes #118 

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added `Exporter\Exporter` class to provide a Symfony `StreamedResponse`.
- Added a `sonata.exporter.exporter` service to deprecate the one defined in the admin bundle
```

## To do

- [x] Consider moving the deprecations to the core bundle

## Subject

This PR imports the exporter class defined in SonataCoreBundle, and the service defined in the admin bundle, making it configurable in the process.
