### PR TITLE
Advertise export formats

### DIFF
--- a/src/Exporter.php
+++ b/src/Exporter.php
@@ -72,6 +72,16 @@ final class Exporter
     }
 
     /**
+     * Returns a simple array of export formats.
+     *
+     * @return string[] writer formats as returned by the TypedWriterInterface::getFormat() method
+     */
+    public function getAvailableFormats()
+    {
+        return array_keys($this->writers);
+    }
+
+    /**
      * The main benefit of this method is the type hinting.
      *
      * @param TypedWriterInterface $writer a possible writer for exporting data

--- a/test/ExporterTest.php
+++ b/test/ExporterTest.php
@@ -56,11 +56,11 @@ class ExporterTest extends \PHPUnit_Framework_TestCase
             ->willReturn('application/made-up');
 
         $exporter = new Exporter(array(
-            'csv' => new CsvWriter('php://output', ',', '"', '', true, true),
-            'json' => new JsonWriter('php://output'),
-            'xls' => new XlsWriter('php://output'),
-            'xml' => new XmlWriter('php://output'),
-            'made-up' => $writer,
+            new CsvWriter('php://output', ',', '"', '', true, true),
+            new JsonWriter('php://output'),
+            new XlsWriter('php://output'),
+            new XmlWriter('php://output'),
+            $writer,
         ));
         $response = $exporter->getResponse($format, $filename, $source);
 

--- a/test/ExporterTest.php
+++ b/test/ExporterTest.php
@@ -39,6 +39,16 @@ class ExporterTest extends \PHPUnit_Framework_TestCase
         new Exporter(array('Not even an object'));
     }
 
+    public function testGetAvailableFormats()
+    {
+        $writer = $this->getMock('Exporter\Writer\TypedWriterInterface');
+        $writer->expects($this->once())
+            ->method('getFormat')
+            ->willReturn('whatever');
+        $exporter = new Exporter(array($writer));
+        $this->assertSame(array('whatever'), $exporter->getAvailableFormats());
+    }
+
     /**
      * @dataProvider getGetResponseTests
      */


### PR DESCRIPTION
I am targetting this branch, because this is backwards-compatible

## Changelog

```markdown
### Added
- Added some `Exporter::getAvailableFormats` to retrieve the list of the formats of the registered writers
```

## To do

Nothing, I hope

## Subject

I'd like to make the admin bundle more flexible about exports, and this method should allow us to have the export formats list nicely update each time we add a new writer.