### PR TITLE
Better support for exports to MS Excel

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "symfony/http-kernel": "^2.3 || ^3.0",
         "symfony/phpunit-bridge": "^2.7 || ^3.0",
         "symfony/property-access": "^2.3 || ^3.0",
-        "symfony/routing": "^2.3 || ^3.0",
+        "symfony/routing": "^2.3 || ^3.0"
     },
     "suggest": {
         "ext-curl": "*",

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     },
     "suggest": {
         "ext-curl": "*",
-        "phpoffice/phpexcel": "^1.8",
+        "phpoffice/phpexcel": "If you want to use XlsExcelWriter with better support for Office 365",
         "propel/propel1": "^1.6",
         "symfony/property-access": "^2.3 || ^3.0",
         "symfony/routing": "^2.3 || ^3.0"

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
         "symfony/http-kernel": "^2.3 || ^3.0",
         "symfony/phpunit-bridge": "^2.7 || ^3.0",
         "symfony/property-access": "^2.3 || ^3.0",
-        "symfony/routing": "^2.3 || ^3.0"
+        "symfony/routing": "^2.3 || ^3.0",
+        "phpoffice/phpexcel": "1.8.*"
     },
     "suggest": {
         "ext-curl": "*",

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         "doctrine/dbal": "^2.2",
         "matthiasnoback/symfony-config-test": "^1.2.1 || ^2.0",
         "matthiasnoback/symfony-dependency-injection-test": "^0.7.6 || ^1.0",
+        "phpoffice/phpexcel": "^1.8",
         "propel/propel1": "^1.6",
         "sllh/php-cs-fixer-styleci-bridge": "^2.0",
         "symfony/dependency-injection": "^2.3 || ^3.0",
@@ -27,10 +28,10 @@
         "symfony/phpunit-bridge": "^2.7 || ^3.0",
         "symfony/property-access": "^2.3 || ^3.0",
         "symfony/routing": "^2.3 || ^3.0",
-        "phpoffice/phpexcel": "1.8.*"
     },
     "suggest": {
         "ext-curl": "*",
+        "phpoffice/phpexcel": "^1.8",
         "propel/propel1": "^1.6",
         "symfony/property-access": "^2.3 || ^3.0",
         "symfony/routing": "^2.3 || ^3.0"

--- a/src/Writer/XlsExcelWriter.php
+++ b/src/Writer/XlsExcelWriter.php
@@ -1,6 +1,12 @@
 <?php
-/**
- * @author Lukáš Brzák <lukas.brzak@email.cz>
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
  */
 
 namespace Exporter\Writer;
@@ -10,6 +16,7 @@ namespace Exporter\Writer;
  * @see https://github.com/PHPOffice/PHPExcel
  *
  * @package Exporter\Writer
+ * @author Lukáš Brzák <lukas.brzak@email.cz>
  */
 class XlsExcelWriter implements TypedWriterInterface
 {
@@ -177,5 +184,4 @@ class XlsExcelWriter implements TypedWriterInterface
     {
         return 'xls';
     }
-
 }

--- a/src/Writer/XlsExcelWriter.php
+++ b/src/Writer/XlsExcelWriter.php
@@ -51,7 +51,7 @@ class XlsExcelWriter implements TypedWriterInterface
     public function __construct($file = 'php://output', $showHeaders = true)
     {
         $this->file = $file;
-        $this->showHeaders = true;
+        $this->showHeaders = $showHeaders;
         $this->configure();
     }
 

--- a/src/Writer/XlsExcelWriter.php
+++ b/src/Writer/XlsExcelWriter.php
@@ -1,0 +1,181 @@
+<?php
+/**
+ * @author Lukáš Brzák <lukas.brzak@email.cz>
+ */
+
+namespace Exporter\Writer;
+
+/**
+ * .xls writer bridge for library `phpoffice/phpexcel`
+ * @see https://github.com/PHPOffice/PHPExcel
+ *
+ * @package Exporter\Writer
+ */
+class XlsExcelWriter implements TypedWriterInterface
+{
+    /** @var \PHPExcel $excel */
+    protected $excel;
+
+    /** @var \PHPExcel_Worksheet $sheet */
+    protected $sheet;
+
+    /** @var \PHPExcel_Writer_Excel2007 $writer */
+    protected $writer;
+
+    /** @var string $column */
+    protected $column = 'A';
+
+    /** @var int $row */
+    protected $row = 1;
+
+    /** @var string $file */
+    protected $file;
+
+    /** @var boolean $showHeaders */
+    protected $showHeaders;
+
+
+    /**
+     * @param string $file
+     * @param bool $showHeaders
+     *
+     * @throws \PHPExcel_Exception
+     */
+    public function __construct($file = 'php://output', $showHeaders = true)
+    {
+        $this->file = $file;
+        $this->showHeaders = true;
+        $this->configure();
+    }
+
+    /**
+     * @return void
+     * @throws \PHPExcel_Exception
+     */
+    protected function configure()
+    {
+        $this->excel = new \PHPExcel();
+        $this->excel->setActiveSheetIndex(0);
+        $this->sheet = $this->excel->getActiveSheet();
+        $this->column = 'A';
+        $this->row = 1;
+    }
+
+    /**
+     * @return void
+     */
+    public function open()
+    {
+        $this->writer = new \PHPExcel_Writer_Excel2007($this->excel);
+    }
+
+    /**
+     * @param array $data
+     *
+     * @throws \PHPExcel_Writer_Exception
+     */
+    public function write(array $data)
+    {
+        $this->init($data);
+
+        foreach ($data as $header => $value) {
+            $this->sheet->setCellValue(
+                $this->getCurrentCell(),
+                $value
+            );
+            $this->nextColumn();
+        }
+        $this->nextRow();
+    }
+
+    /**
+     * Save the initial row of headers
+     *
+     * @param array $data
+     */
+    protected function init(array $data)
+    {
+        if ($this->row > 1) {
+            return;
+        }
+
+        if ($this->showHeaders === true) {
+            foreach ($data as $header => $value) {
+                $this->sheet->setCellValue(
+                    $this->getCurrentCell(),
+                    $header
+                );
+                $this->nextColumn();
+            }
+            $this->nextRow();
+        }
+    }
+
+    /**
+     * Save the file
+     *
+     * @throws \PHPExcel_Writer_Exception
+     */
+    public function close()
+    {
+        $this->writer->save($this->file);
+    }
+
+    /**
+     * Get coordinates for current Cell A1, B2, AB22 ..
+     *
+     * @return string
+     */
+    protected function getCurrentCell()
+    {
+        return sprintf('%s%s', $this->column, $this->row);
+    }
+
+    /**
+     * Increment row number
+     *
+     * @return void
+     */
+    protected function nextRow()
+    {
+        ++$this->row;
+        $this->resetColumn();
+    }
+
+    /**
+     * Increment `A`>`B`; `Z`>`AA`; `AA`>`AB`; `AAZ`>`ABA`
+     *
+     * @return void
+     */
+    protected function nextColumn()
+    {
+        ++$this->column;
+    }
+
+    /**
+     * Reset pointer to the first Excel column A
+     *
+     * @return void
+     */
+    protected function resetColumn()
+    {
+        $this->column = 'A';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    final public function getDefaultMimeType()
+    {
+        return 'application/vnd.ms-excel';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    final public function getFormat()
+    {
+        return 'xls';
+    }
+
+}

--- a/src/Writer/XlsExcelWriter.php
+++ b/src/Writer/XlsExcelWriter.php
@@ -17,7 +17,7 @@ namespace Exporter\Writer;
  *
  * @author Lukáš Brzák <lukas.brzak@email.cz>
  */
-class XlsExcelWriter implements TypedWriterInterface
+final class XlsExcelWriter implements TypedWriterInterface
 {
     /** @var \PHPExcel $excel */
     protected $excel;

--- a/src/Writer/XlsExcelWriter.php
+++ b/src/Writer/XlsExcelWriter.php
@@ -15,7 +15,6 @@ namespace Exporter\Writer;
  * .xls writer bridge for library `phpoffice/phpexcel`
  * @see https://github.com/PHPOffice/PHPExcel
  *
- * @package Exporter\Writer
  * @author Lukáš Brzák <lukas.brzak@email.cz>
  */
 class XlsExcelWriter implements TypedWriterInterface

--- a/src/Writer/XlsExcelWriter.php
+++ b/src/Writer/XlsExcelWriter.php
@@ -12,7 +12,8 @@
 namespace Exporter\Writer;
 
 /**
- * .xls writer bridge for library `phpoffice/phpexcel`
+ * .xls writer bridge for library `phpoffice/phpexcel`.
+ *
  * @see https://github.com/PHPOffice/PHPExcel
  *
  * @author Lukáš Brzák <lukas.brzak@email.cz>
@@ -37,13 +38,12 @@ final class XlsExcelWriter implements TypedWriterInterface
     /** @var string $file */
     protected $file;
 
-    /** @var boolean $showHeaders */
+    /** @var bool $showHeaders */
     protected $showHeaders;
-
 
     /**
      * @param string $file
-     * @param bool $showHeaders
+     * @param bool   $showHeaders
      *
      * @throws \PHPExcel_Exception
      */
@@ -54,22 +54,7 @@ final class XlsExcelWriter implements TypedWriterInterface
         $this->configure();
     }
 
-    /**
-     * @return void
-     * @throws \PHPExcel_Exception
-     */
-    protected function configure()
-    {
-        $this->excel = new \PHPExcel();
-        $this->excel->setActiveSheetIndex(0);
-        $this->sheet = $this->excel->getActiveSheet();
-        $this->column = 'A';
-        $this->row = 1;
-    }
 
-    /**
-     * @return void
-     */
     public function open()
     {
         $this->writer = new \PHPExcel_Writer_Excel2007($this->excel);
@@ -95,7 +80,45 @@ final class XlsExcelWriter implements TypedWriterInterface
     }
 
     /**
-     * Save the initial row of headers
+     * Save the file.
+     *
+     * @throws \PHPExcel_Writer_Exception
+     */
+    public function close()
+    {
+        $this->writer->save($this->file);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    final public function getDefaultMimeType()
+    {
+        return 'application/vnd.ms-excel';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    final public function getFormat()
+    {
+        return 'xls';
+    }
+
+    /**
+     * @throws \PHPExcel_Exception
+     */
+    protected function configure()
+    {
+        $this->excel = new \PHPExcel();
+        $this->excel->setActiveSheetIndex(0);
+        $this->sheet = $this->excel->getActiveSheet();
+        $this->column = 'A';
+        $this->row = 1;
+    }
+
+    /**
+     * Save the initial row of headers.
      *
      * @param array $data
      */
@@ -118,16 +141,6 @@ final class XlsExcelWriter implements TypedWriterInterface
     }
 
     /**
-     * Save the file
-     *
-     * @throws \PHPExcel_Writer_Exception
-     */
-    public function close()
-    {
-        $this->writer->save($this->file);
-    }
-
-    /**
      * Get coordinates for current Cell A1, B2, AB22 ..
      *
      * @return string
@@ -138,9 +151,7 @@ final class XlsExcelWriter implements TypedWriterInterface
     }
 
     /**
-     * Increment row number
-     *
-     * @return void
+     * Increment row number.
      */
     protected function nextRow()
     {
@@ -149,9 +160,7 @@ final class XlsExcelWriter implements TypedWriterInterface
     }
 
     /**
-     * Increment `A`>`B`; `Z`>`AA`; `AA`>`AB`; `AAZ`>`ABA`
-     *
-     * @return void
+     * Increment `A`>`B`; `Z`>`AA`; `AA`>`AB`; `AAZ`>`ABA`.
      */
     protected function nextColumn()
     {
@@ -159,28 +168,10 @@ final class XlsExcelWriter implements TypedWriterInterface
     }
 
     /**
-     * Reset pointer to the first Excel column A
-     *
-     * @return void
+     * Reset pointer to the first Excel column A.
      */
     protected function resetColumn()
     {
         $this->column = 'A';
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    final public function getDefaultMimeType()
-    {
-        return 'application/vnd.ms-excel';
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    final public function getFormat()
-    {
-        return 'xls';
     }
 }

--- a/src/Writer/XlsExcelWriter.php
+++ b/src/Writer/XlsExcelWriter.php
@@ -54,7 +54,6 @@ final class XlsExcelWriter implements TypedWriterInterface
         $this->configure();
     }
 
-
     public function open()
     {
         $this->writer = new \PHPExcel_Writer_Excel2007($this->excel);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/exporter/blob/1.x/CONTRIBUTING.md#the-base-branch
-->

When you want to export XLS and open with MS Office 365 with standard XlsWriter, it fails. It is better to use library phpoffice/phpexcel to work on latest Office.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->
## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->

``` markdown
### Added
- Added `XlsExcelWriter`

```
## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->
- [ ] Add tests
- [ ] Add documentation
- [ ] Fix the build
