### PR TITLE
Make \Exporter\Exporter::addWriter public

### DIFF
--- a/src/Exporter.php
+++ b/src/Exporter.php
@@ -86,7 +86,7 @@ final class Exporter
      *
      * @param TypedWriterInterface $writer a possible writer for exporting data
      */
-    private function addWriter(TypedWriterInterface $writer)
+    public function addWriter(TypedWriterInterface $writer)
     {
         $this->writers[$writer->getFormat()] = $writer;
     }


### PR DESCRIPTION
Make \Exporter\Exporter::addWriter public.

This will fix Symfony embedded bundle since we call this function to create default sonata.exporter.exporter service.

Plus, it could be useful to have it public.