### PR TITLE
Fix Exporter crashing when foreign data objects are null

### DIFF
--- a/src/Source/DoctrineODMQuerySourceIterator.php
+++ b/src/Source/DoctrineODMQuerySourceIterator.php
@@ -81,6 +81,7 @@ class DoctrineODMQuerySourceIterator implements SourceIteratorInterface
             }
         }
         $this->query->getDocumentManager()->getUnitOfWork()->detach($current);
+        
         return $data;
     }
 

--- a/src/Source/DoctrineODMQuerySourceIterator.php
+++ b/src/Source/DoctrineODMQuerySourceIterator.php
@@ -81,6 +81,7 @@ class DoctrineODMQuerySourceIterator implements SourceIteratorInterface
             }
         }
         $this->query->getDocumentManager()->getUnitOfWork()->detach($current);
+
         return $data;
     }
 

--- a/src/Source/DoctrineODMQuerySourceIterator.php
+++ b/src/Source/DoctrineODMQuerySourceIterator.php
@@ -75,12 +75,14 @@ class DoctrineODMQuerySourceIterator implements SourceIteratorInterface
         $current = $this->iterator->current();
         
         $data = array();
+        
         foreach ($this->propertyPaths as $name => $propertyPath) {
             $data[$name] = '';
             if ($this->propertyAccessor->isReadable($current, $propertyPath)) {
                 $data[$name] = $this->getValue($this->propertyAccessor->getValue($current, $propertyPath));
             }
         }
+        
         $this->query->getDocumentManager()->getUnitOfWork()->detach($current);
         
         return $data;

--- a/src/Source/DoctrineODMQuerySourceIterator.php
+++ b/src/Source/DoctrineODMQuerySourceIterator.php
@@ -82,6 +82,7 @@ class DoctrineODMQuerySourceIterator implements SourceIteratorInterface
             }
         }
         $this->query->getDocumentManager()->getUnitOfWork()->detach($current);
+        
         return $data;
     }
 

--- a/src/Source/DoctrineODMQuerySourceIterator.php
+++ b/src/Source/DoctrineODMQuerySourceIterator.php
@@ -75,9 +75,24 @@ class DoctrineODMQuerySourceIterator implements SourceIteratorInterface
         $current = $this->iterator->current();
 
         $data = array();
-
         foreach ($this->propertyPaths as $name => $propertyPath) {
+
+          // Is the property extended
+          if(strpos($propertyPath, '.'))
+          {
+            $data[$name] = '';
+            // Construct the get method
+            $getMethod =  'get'.ucfirst(strstr($propertyPath, ".", true));
+            // Check whether there is an object
+            if($current->$getMethod())
+            {
+              $data[$name] = $this->getValue($this->propertyAccessor->getValue($current, $propertyPath));
+            }
+          }
+          else
+          {
             $data[$name] = $this->getValue($this->propertyAccessor->getValue($current, $propertyPath));
+          }
         }
 
         $this->query->getDocumentManager()->getUnitOfWork()->detach($current);

--- a/src/Source/DoctrineODMQuerySourceIterator.php
+++ b/src/Source/DoctrineODMQuerySourceIterator.php
@@ -73,18 +73,14 @@ class DoctrineODMQuerySourceIterator implements SourceIteratorInterface
     public function current()
     {
         $current = $this->iterator->current();
-        
         $data = array();
-        
         foreach ($this->propertyPaths as $name => $propertyPath) {
             $data[$name] = '';
             if ($this->propertyAccessor->isReadable($current, $propertyPath)) {
                 $data[$name] = $this->getValue($this->propertyAccessor->getValue($current, $propertyPath));
             }
         }
-        
-        $this->query->getDocumentManager()->getUnitOfWork()->detach($current);
-        
+        $this->query->getDocumentManager()->getUnitOfWork()->detach($current);        
         return $data;
     }
 

--- a/src/Source/DoctrineODMQuerySourceIterator.php
+++ b/src/Source/DoctrineODMQuerySourceIterator.php
@@ -73,6 +73,7 @@ class DoctrineODMQuerySourceIterator implements SourceIteratorInterface
     public function current()
     {
         $current = $this->iterator->current();
+        
         $data = array();
         foreach ($this->propertyPaths as $name => $propertyPath) {
             $data[$name] = '';

--- a/src/Source/DoctrineODMQuerySourceIterator.php
+++ b/src/Source/DoctrineODMQuerySourceIterator.php
@@ -81,7 +81,6 @@ class DoctrineODMQuerySourceIterator implements SourceIteratorInterface
             }
         }
         $this->query->getDocumentManager()->getUnitOfWork()->detach($current);
-        
         return $data;
     }
 

--- a/src/Source/DoctrineODMQuerySourceIterator.php
+++ b/src/Source/DoctrineODMQuerySourceIterator.php
@@ -78,20 +78,16 @@ class DoctrineODMQuerySourceIterator implements SourceIteratorInterface
         foreach ($this->propertyPaths as $name => $propertyPath) {
 
           // Is the property extended
-          if(strpos($propertyPath, '.'))
-          {
+          if (strpos($propertyPath, '.')) {
             $data[$name] = '';
             // Construct the get method
-            $getMethod =  'get'.ucfirst(strstr($propertyPath, ".", true));
+            $getMethod = 'get'.ucfirst(strstr($propertyPath, '.', true));
             // Check whether there is an object
-            if($current->$getMethod())
-            {
-              $data[$name] = $this->getValue($this->propertyAccessor->getValue($current, $propertyPath));
+            if ($current->$getMethod()) {
+                $data[$name] = $this->getValue($this->propertyAccessor->getValue($current, $propertyPath));
             }
-          }
-          else
-          {
-            $data[$name] = $this->getValue($this->propertyAccessor->getValue($current, $propertyPath));
+          } else {
+              $data[$name] = $this->getValue($this->propertyAccessor->getValue($current, $propertyPath));
           }
         }
 

--- a/src/Source/DoctrineODMQuerySourceIterator.php
+++ b/src/Source/DoctrineODMQuerySourceIterator.php
@@ -80,7 +80,7 @@ class DoctrineODMQuerySourceIterator implements SourceIteratorInterface
                 $data[$name] = $this->getValue($this->propertyAccessor->getValue($current, $propertyPath));
             }
         }
-        $this->query->getDocumentManager()->getUnitOfWork()->detach($current);        
+        $this->query->getDocumentManager()->getUnitOfWork()->detach($current);
         return $data;
     }
 

--- a/src/Source/DoctrineODMQuerySourceIterator.php
+++ b/src/Source/DoctrineODMQuerySourceIterator.php
@@ -78,7 +78,7 @@ class DoctrineODMQuerySourceIterator implements SourceIteratorInterface
         foreach ($this->propertyPaths as $name => $propertyPath) {
             $data[$name] = '';
             if ($this->propertyAccessor->isReadable($current, $propertyPath)) {
-              $data[$name] = $this->getValue($this->propertyAccessor->getValue($current, $propertyPath));
+                $data[$name] = $this->getValue($this->propertyAccessor->getValue($current, $propertyPath));
             }
         }
 

--- a/src/Source/DoctrineODMQuerySourceIterator.php
+++ b/src/Source/DoctrineODMQuerySourceIterator.php
@@ -76,11 +76,10 @@ class DoctrineODMQuerySourceIterator implements SourceIteratorInterface
 
         $data = array();
         foreach ($this->propertyPaths as $name => $propertyPath) {
-
-          $data[$name] = '';
-          if ($this->propertyAccessor->isReadable($current, $propertyPath)) {
-            $data[$name] = $this->getValue($this->propertyAccessor->getValue($current, $propertyPath));
-          }
+            $data[$name] = '';
+            if ($this->propertyAccessor->isReadable($current, $propertyPath)) {
+              $data[$name] = $this->getValue($this->propertyAccessor->getValue($current, $propertyPath));
+            }
         }
 
         $this->query->getDocumentManager()->getUnitOfWork()->detach($current);

--- a/src/Source/DoctrineODMQuerySourceIterator.php
+++ b/src/Source/DoctrineODMQuerySourceIterator.php
@@ -145,8 +145,14 @@ class DoctrineODMQuerySourceIterator implements SourceIteratorInterface
      */
     protected function getValue($value)
     {
-        if (is_array($value) || $value instanceof \Traversable) {
-            $value = null;
+        //if value is array or collection, creates string
+        if (is_array($value) or $value instanceof \Traversable) {
+            $result = array();
+            foreach ($value as $item) {
+                $result[] = $this->getValue($item);
+            }
+            $value = implode(', ', $result);
+            //formated datetime output
         } elseif ($value instanceof \DateTime) {
             $value = $value->format($this->dateTimeFormat);
         } elseif (is_object($value)) {

--- a/src/Source/DoctrineODMQuerySourceIterator.php
+++ b/src/Source/DoctrineODMQuerySourceIterator.php
@@ -73,7 +73,6 @@ class DoctrineODMQuerySourceIterator implements SourceIteratorInterface
     public function current()
     {
         $current = $this->iterator->current();
-
         $data = array();
         foreach ($this->propertyPaths as $name => $propertyPath) {
             $data[$name] = '';
@@ -81,9 +80,7 @@ class DoctrineODMQuerySourceIterator implements SourceIteratorInterface
                 $data[$name] = $this->getValue($this->propertyAccessor->getValue($current, $propertyPath));
             }
         }
-
         $this->query->getDocumentManager()->getUnitOfWork()->detach($current);
-
         return $data;
     }
 

--- a/src/Source/DoctrineODMQuerySourceIterator.php
+++ b/src/Source/DoctrineODMQuerySourceIterator.php
@@ -77,17 +77,9 @@ class DoctrineODMQuerySourceIterator implements SourceIteratorInterface
         $data = array();
         foreach ($this->propertyPaths as $name => $propertyPath) {
 
-          // Is the property extended
-          if (strpos($propertyPath, '.')) {
-            $data[$name] = '';
-            // Construct the get method
-            $getMethod = 'get'.ucfirst(strstr($propertyPath, '.', true));
-            // Check whether there is an object
-            if ($current->$getMethod()) {
-                $data[$name] = $this->getValue($this->propertyAccessor->getValue($current, $propertyPath));
-            }
-          } else {
-              $data[$name] = $this->getValue($this->propertyAccessor->getValue($current, $propertyPath));
+          $data[$name] = '';
+          if ($this->propertyAccessor->isReadable($current, $propertyPath)) {
+            $data[$name] = $this->getValue($this->propertyAccessor->getValue($current, $propertyPath));
           }
         }
 
@@ -157,7 +149,7 @@ class DoctrineODMQuerySourceIterator implements SourceIteratorInterface
     protected function getValue($value)
     {
         //if value is array or collection, creates string
-        if (is_array($value) or $value instanceof \Traversable) {
+        if (is_array($value) || $value instanceof \Traversable) {
             $result = array();
             foreach ($value as $item) {
                 $result[] = $this->getValue($item);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/exporter/blob/1.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because it is the one where bug fixes go
<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown

### Changed
- current method from the Data Iterator to check whether the referenced document exists

### Fixed
- `PropertyAccessor` crashed if using referenced documents if they are `null`
```

## Subject

The method begins by checking for the presence of a "." in the export field. If found, it is a foreign object so it then checks whether the foreign object really exists or not by trying to get it.
