### PR TITLE
Improve DateTime formatting/granularity

### DIFF
--- a/src/Formatter/ArrayFormatter.php
+++ b/src/Formatter/ArrayFormatter.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Exporter\Formatter;
+
+use Symfony\Component\PropertyAccess\PropertyPath;
+
+final class ArrayFormatter implements DataFormatterInterface
+{
+    /**
+     * @inheritDoc
+     */
+    public function supports($data)
+    {
+        return (is_array($data) || $data instanceof \Traversable);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function format($data, PropertyPath $propertyPath)
+    {
+        return null;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getPriority()
+    {
+        return 10;
+    }
+}

--- a/src/Formatter/DataFormatterInterface.php
+++ b/src/Formatter/DataFormatterInterface.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Exporter\Formatter;
+
+use Symfony\Component\PropertyAccess\PropertyPath;
+
+/**
+ * Interface to implement for data formatters that will handle some
+ * input and format the output as desired for exporting. For example
+ * this can be used to format DateTime instances or any other objects
+ * that require custom or additional logic when exported as a string.
+ */
+interface DataFormatterInterface
+{
+    /**
+     * Determine if we know how to format this particular data type
+     *
+     * @param $data
+     * @return bool
+     */
+    public function supports($data);
+
+    /**
+     * Formats data
+     *
+     * @param $data
+     * @param PropertyPath $propertyPath
+     * @return string
+     */
+    public function format($data, PropertyPath $propertyPath);
+
+    /**
+     * Returns where in the formatting stack this should land must be greater than 0
+     * Lower priority is processed first. The first formatter found that supports a
+     * particular data type is called and no further processing occurs.
+     *
+     * @return int
+     */
+    public function getPriority();
+}

--- a/src/Formatter/DateTimeFormatter.php
+++ b/src/Formatter/DateTimeFormatter.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Exporter\Formatter;
+
+use Symfony\Component\PropertyAccess\PropertyPath;
+
+final class DateTimeFormatter implements DataFormatterInterface
+{
+    /** @var null|string */
+    private $format = null;
+
+    /**
+     * DateTimeFormatter constructor.
+     * @param null|string $dateTimeFormat
+     */
+    public function __construct($dateTimeFormat = 'r')
+    {
+        $this->format = $dateTimeFormat;
+    }
+
+    /**
+     * @inheritDoc
+     * NEXT_MAJOR: can drop instanceof \DateTime can be removed when dropping php < 5.5
+     */
+    public function supports($data)
+    {
+        return $data instanceof \DateTime || $data instanceof \DateTimeInterface;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function format($data, PropertyPath $propertyPath)
+    {
+        return $data->format($this->format);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getPriority()
+    {
+        return 100;
+    }
+}

--- a/src/Formatter/ObjectToStringFormatter.php
+++ b/src/Formatter/ObjectToStringFormatter.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Exporter\Formatter;
+
+use Symfony\Component\PropertyAccess\PropertyPath;
+
+final class ObjectToStringFormatter implements DataFormatterInterface
+{
+    /**
+     * @inheritDoc
+     */
+    public function supports($data)
+    {
+        return is_object($data);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function format($data, PropertyPath $propertyPath)
+    {
+        return (string) $data;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getPriority()
+    {
+        return 200;
+    }
+}


### PR DESCRIPTION
I am targeting this branch, because this is a BC safe change.

## Changelog
Added ability to format a DateTime per source property

```markdown
### Added
- Added ability to format dates on a per property basis for DoctrineORM/ODM Query Sources.
```
## To do
Add tests if the basic idea is acceptable
Expand to cover any other Source interfaces that could benefit from a similar ability.

- [ ] Update the tests
- [ ] Update the documentation
- [ ] Add an upgrade note

## Subject
This adds the ability to two DoctrineQuerySourceInterators to format
each DateTime field individually. It also allows for any source interface to be more extensible.
