### PR TITLE
Update symfony.rst

### DIFF
--- a/docs/reference/symfony.rst
+++ b/docs/reference/symfony.rst
@@ -18,7 +18,7 @@ Registering the bundle
     {
         $bundles = array(
             // …
-            new Exporter\Bridge\Symfony\Bundle\SonataExporterBundle();
+            new Exporter\Bridge\Symfony\Bundle\SonataExporterBundle(),
         );
 
         // …


### PR DESCRIPTION
I am targeting this branch, because this is backwards compatible.

## Changelog
### Fixed
```
docs/reference/symfony.rst
```
## Subject

The register bundle section has an error in the code. Since this is registered within an array, the line needs to end with `,` not `;`

