### PR TITLE
Add seekable csv source

### DIFF
--- a/src/Source/SeekableSourceIteratorInterface.php
+++ b/src/Source/SeekableSourceIteratorInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\Exporter\Source;
+
+/**
+ * @author Sylvain Rascar <sylvain.rascar@ekino.com>
+ */
+interface SeekableSourceIteratorInterface extends SourceIteratorInterface, \SeekableIterator
+{
+}

--- a/test/Source/CsvSourceIteratorTest.php
+++ b/test/Source/CsvSourceIteratorTest.php
@@ -90,4 +90,43 @@ EOF;
         }
         $this->assertEquals(3, $i);
     }
+
+    public function testSeek()
+    {
+        $iterator = new CsvSourceIterator($this->filename);
+
+        $iterator->seek(1);
+        $value = $iterator->current();
+        $this->assertTrue(is_array($value));
+        $this->assertEquals('John 2', $value['firstname']);
+    }
+
+    public function testSeekNoHeaders()
+    {
+        $iterator = new CsvSourceIterator($this->filename, ',', '"', '\\', false);
+
+        $iterator->seek(1);
+        $value = $iterator->current();
+        $this->assertTrue(is_array($value));
+        $this->assertEquals('John 1', $value[0]);
+    }
+
+    public function testInvalidColumns()
+    {
+        if (is_file($this->filename)) {
+            unlink($this->filename);
+        }
+
+        $csv = <<<'EOF'
+firstname,name
+John 1,Doe
+John 2,Doe, extra
+"John, 3", Doe
+EOF;
+        file_put_contents($this->filename, $csv);
+        $this->expectException('RuntimeException');
+
+        $iterator = new CsvSourceIterator($this->filename);
+        $iterator->seek(1);
+    }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/exporter/blob/1.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because I want to implement a series of new feature that will
eventually cause BC-break.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog
<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Seekable csv source
```

## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

- [x] Update the tests
- [ ] Update the documentation
- [ ] Add an upgrade note

## Subject

<!-- Describe your Pull Request content here -->
I want to add new features to exporter in order to improve it's functionalities.
The first step is to allow the source to be seekable.
This combined with a few other classes will provide much more flexibility and possibilities 
to the bundle