### PR TITLE
Drop old versions of php/sf

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,20 +13,20 @@
         }
     ],
     "require": {
-        "php": "^5.3 || ^7.0"
+        "php": "^7.1"
     },
     "require-dev": {
         "doctrine/dbal": "^2.2",
-        "matthiasnoback/symfony-config-test": "^1.2.1 || ^2.0",
-        "matthiasnoback/symfony-dependency-injection-test": "^0.7.6 || ^1.0",
+        "matthiasnoback/symfony-config-test": "^2.0",
+        "matthiasnoback/symfony-dependency-injection-test": "^1.0",
         "propel/propel1": "^1.6",
         "sllh/php-cs-fixer-styleci-bridge": "^2.0",
-        "symfony/dependency-injection": "^2.3 || ^3.0",
-        "symfony/http-foundation": "^2.3 || ^3.0",
-        "symfony/http-kernel": "^2.3 || ^3.0",
-        "symfony/phpunit-bridge": "^2.7 || ^3.0",
-        "symfony/property-access": "^2.3 || ^3.0",
-        "symfony/routing": "^2.3 || ^3.0"
+        "symfony/dependency-injection": "^2.8 || ^3.2",
+        "symfony/http-foundation": "^2.8 || ^3.2",
+        "symfony/http-kernel": "^2.8 || ^3.2",
+        "symfony/phpunit-bridge": "^3.3",
+        "symfony/property-access": "^2.8 || ^3.2",
+        "symfony/routing": "^2.8 || ^3.2"
     },
     "suggest": {
         "ext-curl": "*",


### PR DESCRIPTION
I am targeting this branch, because this is BC.

## Changelog

```markdown
### Removed
- Support for old versions of PHP and Symfony.
```
