### PR TITLE
Replace type checking of DateTime with DateTimeInterface

### DIFF
--- a/src/Source/DoctrineODMQuerySourceIterator.php
+++ b/src/Source/DoctrineODMQuerySourceIterator.php
@@ -147,7 +147,7 @@ class DoctrineODMQuerySourceIterator implements SourceIteratorInterface
     {
         if (is_array($value) || $value instanceof \Traversable) {
             $value = null;
-        } elseif ($value instanceof \DateTime) {
+        } elseif ($value instanceof \DateTimeInterface) {
             $value = $value->format($this->dateTimeFormat);
         } elseif (is_object($value)) {
             $value = (string) $value;

--- a/src/Source/DoctrineORMQuerySourceIterator.php
+++ b/src/Source/DoctrineORMQuerySourceIterator.php
@@ -156,7 +156,7 @@ class DoctrineORMQuerySourceIterator implements SourceIteratorInterface
     {
         if (is_array($value) || $value instanceof \Traversable) {
             $value = null;
-        } elseif ($value instanceof \DateTime) {
+        } elseif ($value instanceof \DateTimeInterface) {
             $value = $value->format($this->dateTimeFormat);
         } elseif (is_object($value)) {
             $value = (string) $value;

--- a/src/Source/PropelCollectionSourceIterator.php
+++ b/src/Source/PropelCollectionSourceIterator.php
@@ -150,7 +150,7 @@ class PropelCollectionSourceIterator implements SourceIteratorInterface
     {
         if (is_array($value) || $value instanceof \Traversable) {
             $value = null;
-        } elseif ($value instanceof \DateTime) {
+        } elseif ($value instanceof \DateTimeInterface) {
             $value = $value->format($this->dateTimeFormat);
         } elseif (is_object($value)) {
             $value = (string) $value;


### PR DESCRIPTION
I am targeting this branch, because there are no BC breaks.

## Changelog

```markdown
### Fixed
- Allow `\DateTimeImmutable` values
```

## Subject

This PR changes value type checking from `instanceof \DateTime` to `instanceof \DateTimeInterface`, which allows `\DateTimeImmutable` values to be exported correctly. Previously, this would cause a fatal error "Object of class DateTimeImmutable could not be converted to string at vendor/sonata-project/exporter/src/Source/DoctrineORMQuerySourceIterator.php:161)".