### PR TITLE
Make php 7.1 requirement explicit

### DIFF
--- a/UPGRADE-2.0.md
+++ b/UPGRADE-2.0.md
@@ -1,6 +1,10 @@
 UPGRADE FROM 1.x to 2.0
 =======================
 
+## PHP
+
+PHP 7.1 is required.
+
 ## Symfony
 
 Symfony support is dropped from 2.3 to 2.7 included.

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "php": "^5.6 || ^7.0"
+        "php": "^7.1"
     },
     "require-dev": {
         "doctrine/dbal": "^2.2",


### PR DESCRIPTION
I am targeting this branch, because this is a php major version bump.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- support for php 5.6 - 7.1
```
