### PR TITLE
[Bug] Actually use the escape parameter.

### DIFF
--- a/src/Writer/CsvWriter.php
+++ b/src/Writer/CsvWriter.php
@@ -66,8 +66,14 @@ class CsvWriter implements TypedWriterInterface
      * @param bool   $showHeaders
      * @param bool   $withBom
      */
-    public function __construct($filename, $delimiter = ',', $enclosure = '"', $escape = '\\', $showHeaders = true, $withBom = false)
-    {
+    public function __construct(
+        $filename,
+        $delimiter = ',',
+        $enclosure = '"',
+        $escape = '\\',
+        $showHeaders = true,
+        $withBom = false
+    ) {
         $this->filename = $filename;
         $this->delimiter = $delimiter;
         $this->enclosure = $enclosure;
@@ -127,7 +133,7 @@ class CsvWriter implements TypedWriterInterface
             ++$this->position;
         }
 
-        $result = @fputcsv($this->file, $data, $this->delimiter, $this->enclosure);
+        $result = @fputcsv($this->file, $data, $this->delimiter, $this->enclosure, $this->escape);
 
         if (!$result) {
             throw new InvalidDataFormatException();
@@ -146,6 +152,6 @@ class CsvWriter implements TypedWriterInterface
             $headers[] = $header;
         }
 
-        fputcsv($this->file, $headers, $this->delimiter, $this->enclosure);
+        fputcsv($this->file, $headers, $this->delimiter, $this->enclosure, $this->escape);
     }
 }

--- a/tests/Writer/CsvWriterTest.php
+++ b/tests/Writer/CsvWriterTest.php
@@ -59,9 +59,24 @@ class CsvWriterTest extends AbstractTypedWriterTestCase
         $this->assertEquals($expected, trim(file_get_contents($this->filename)));
     }
 
+    public function testEscapeFormating()
+    {
+        $writer = new CsvWriter($this->filename, ',', '"', '/', false);
+
+        $writer->open();
+
+        $writer->write(['john','doe', '\\', '/']);
+
+        $writer->close();
+
+        $expected = 'john,doe,\,"/"';
+
+        $this->assertEquals($expected, trim(file_get_contents($this->filename)));
+    }
+
     public function testEnclosureFormatingWithExcel()
     {
-        $writer = new CsvWriter($this->filename, ',', '"', '', false);
+        $writer = new CsvWriter($this->filename, ',', '"', '\\', false);
         $writer->open();
 
         $writer->write(['john , ""2"', 'doe ', '1']);
@@ -75,7 +90,7 @@ class CsvWriterTest extends AbstractTypedWriterTestCase
 
     public function testWithHeaders()
     {
-        $writer = new CsvWriter($this->filename, ',', '"', '', true);
+        $writer = new CsvWriter($this->filename, ',', '"', '\\', true);
         $writer->open();
 
         $writer->write(['name' => 'john , ""2"', 'surname' => 'doe ', 'year' => '2001']);
@@ -89,7 +104,7 @@ class CsvWriterTest extends AbstractTypedWriterTestCase
 
     public function testWithBom()
     {
-        $writer = new CsvWriter($this->filename, ',', '"', '', true, true);
+        $writer = new CsvWriter($this->filename, ',', '"', '\\', true, true);
         $writer->open();
 
         $writer->write(['name' => 'Rémi , ""2"', 'surname' => 'doe ', 'year' => '2001']);

--- a/tests/Writer/CsvWriterTest.php
+++ b/tests/Writer/CsvWriterTest.php
@@ -65,7 +65,7 @@ class CsvWriterTest extends AbstractTypedWriterTestCase
 
         $writer->open();
 
-        $writer->write(['john','doe', '\\', '/']);
+        $writer->write(['john', 'doe', '\\', '/']);
 
         $writer->close();
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/exporter/blob/1.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is not BC breaking, just a breakfix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #219 

## Changelog

### Fixed
- CsvWriter actually uses the escape parameter.

## Subject

Simplified version of the PR to just fix the missing params.