### PR TITLE
Support custom CSV termination.

### DIFF
--- a/src/Writer/CsvWriter.php
+++ b/src/Writer/CsvWriter.php
@@ -59,20 +59,34 @@ class CsvWriter implements TypedWriterInterface
     protected $withBom;
 
     /**
+     * @var string
+     */
+    protected $terminate;
+
+    /**
      * @param string $filename
      * @param string $delimiter
      * @param string $enclosure
      * @param string $escape
      * @param bool   $showHeaders
      * @param bool   $withBom
+     * @param string $terminate
      */
-    public function __construct($filename, $delimiter = ',', $enclosure = '"', $escape = '\\', $showHeaders = true, $withBom = false)
-    {
+    public function __construct(
+        $filename,
+        $delimiter = ',',
+        $enclosure = '"',
+        $escape = '\\',
+        $showHeaders = true,
+        $withBom = false,
+        $terminate = "\n"
+    ) {
         $this->filename = $filename;
         $this->delimiter = $delimiter;
         $this->enclosure = $enclosure;
         $this->escape = $escape;
         $this->showHeaders = $showHeaders;
+        $this->terminate = $terminate;
         $this->position = 0;
         $this->withBom = $withBom;
 
@@ -103,6 +117,10 @@ class CsvWriter implements TypedWriterInterface
     public function open()
     {
         $this->file = fopen($this->filename, 'w', false);
+        if ("\n" !== $this->terminate) {
+            stream_filter_register('filterTerminate', 'CsvWriterTerminate');
+            stream_filter_append($this->file, 'filterTerminate', STREAM_FILTER_WRITE, ['terminate' => $this->terminate]);
+        }
         if (true === $this->withBom) {
             fprintf($this->file, chr(0xEF).chr(0xBB).chr(0xBF));
         }

--- a/src/Writer/CsvWriter.php
+++ b/src/Writer/CsvWriter.php
@@ -61,7 +61,7 @@ class CsvWriter implements TypedWriterInterface
     /**
      * @var string
      */
-    protected $terminate;
+    private $terminate;
 
     /**
      * @param string $filename

--- a/src/Writer/CsvWriter.php
+++ b/src/Writer/CsvWriter.php
@@ -118,7 +118,7 @@ class CsvWriter implements TypedWriterInterface
     {
         $this->file = fopen($this->filename, 'w', false);
         if ("\n" !== $this->terminate) {
-            stream_filter_register('filterTerminate', 'CsvWriterTerminate');
+            stream_filter_register('filterTerminate', 'Exporter\Writer\CsvWriterTerminate');
             stream_filter_append($this->file, 'filterTerminate', STREAM_FILTER_WRITE, ['terminate' => $this->terminate]);
         }
         if (true === $this->withBom) {

--- a/src/Writer/CsvWriter.php
+++ b/src/Writer/CsvWriter.php
@@ -118,7 +118,7 @@ class CsvWriter implements TypedWriterInterface
     {
         $this->file = fopen($this->filename, 'w', false);
         if ("\n" !== $this->terminate) {
-            stream_filter_register('filterTerminate', 'Exporter\Writer\CsvWriterTerminate');
+            stream_filter_register('filterTerminate', CsvWriterTerminate::class);
             stream_filter_append($this->file, 'filterTerminate', STREAM_FILTER_WRITE, ['terminate' => $this->terminate]);
         }
         if (true === $this->withBom) {

--- a/src/Writer/CsvWriterTerminate.php
+++ b/src/Writer/CsvWriterTerminate.php
@@ -14,7 +14,7 @@ namespace Exporter\Writer;
 /**
  * Filter CSV output to replace the default terminator while supporting active streams.
  */
-class CsvWriterTerminate extends \php_user_filter
+final class CsvWriterTerminate extends \php_user_filter
 {
     /**
      * @param $in

--- a/src/Writer/CsvWriterTerminate.php
+++ b/src/Writer/CsvWriterTerminate.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Exporter\Writer;
+
+/**
+ * Filter CSV output to replace the default terminator while supporting active streams.
+ */
+class CsvWriterTerminate extends \php_user_filter
+{
+    /**
+     * @param $in
+     * @param $out
+     * @param $consumed
+     * @param $closing
+     *
+     * @return int
+     */
+    public function filter($in, $out, &$consumed, $closing)
+    {
+        while ($bucket = stream_bucket_make_writeable($in)) {
+            if (isset($this->params['terminate'])) {
+                $bucket->data = preg_replace('/([^\r])\n/', '$1'.$this->params['terminate'], $bucket->data);
+            }
+            $consumed += $bucket->datalen;
+            stream_bucket_append($out, $bucket);
+        }
+
+        return PSFS_PASS_ON;
+    }
+}

--- a/tests/Writer/CsvWriterTerminateTest.php
+++ b/tests/Writer/CsvWriterTerminateTest.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Exporter\Test\Writer;
+
+use Exporter\Test\AbstractTypedWriterTestCase;
+use Exporter\Writer\CsvWriter;
+use Exporter\Writer\CsvWriterTerminate;
+
+class CsvWriterTerminateTest extends AbstractTypedWriterTestCase
+{
+    protected $filename;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->filename = 'foobar.csv';
+
+        if (is_file($this->filename)) {
+            unlink($this->filename);
+        }
+    }
+
+    public function tearDown()
+    {
+        if (is_file($this->filename)) {
+            unlink($this->filename);
+        }
+    }
+
+    public function testFilter()
+    {
+        $file = fopen($this->filename, 'w', false);
+        stream_filter_register('filter', CsvWriterTerminate::class);
+        stream_filter_append($file, 'filter', STREAM_FILTER_WRITE, ['terminate' => "\r\n"]);
+        @fputcsv($file, ['john', 'doe', '1']);
+        @fputcsv($file, ['john', 'doe', '2']);
+        fclose($file);
+
+        $expected = "john,doe,1\r\njohn,doe,2";
+
+        $this->assertEquals($expected, trim(file_get_contents($this->filename)));
+    }
+
+    protected function getWriter()
+    {
+        return new CsvWriter('/tmp/whatever.csv');
+    }
+}

--- a/tests/Writer/CsvWriterTest.php
+++ b/tests/Writer/CsvWriterTest.php
@@ -59,6 +59,21 @@ class CsvWriterTest extends AbstractTypedWriterTestCase
         $this->assertEquals($expected, trim(file_get_contents($this->filename)));
     }
 
+    public function testWithTerminate()
+    {
+        $writer = new CsvWriter($this->filename, ',', '"', '\\', false, false, "\r\n");
+        $writer->open();
+
+        $writer->write(['john', 'doe', '1']);
+        $writer->write(['john', 'doe', '2']);
+
+        $writer->close();
+
+        $expected = "john,doe,1\r\njohn,doe,2";
+
+        $this->assertEquals($expected, trim(file_get_contents($this->filename)));
+    }
+
     public function testEnclosureFormatingWithExcel()
     {
         $writer = new CsvWriter($this->filename, ',', '"', '', false);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/exporter/blob/1.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is not BC breaking.

## Changelog
```markdown
### Added
- Added support for custom terminators with `CsvWriter` class
```

## Subject

A small feature addition to aid in the output of CSVs that are to be parsed by old/faulty programs/automation (mostly Microsoft). For example, if it's a program expecting "\r\n" for each line, it may only get the first line of the CSV and stop. Being able to control/manipulate the termination string (aka EOL) is pretty important for legacy support.