### PR TITLE
Make exporter public

### DIFF
--- a/src/Bridge/Symfony/Resources/config/services.xml
+++ b/src/Bridge/Symfony/Resources/config/services.xml
@@ -21,6 +21,6 @@
             <argument>%sonata.exporter.writer.xml.main_element%</argument>
             <argument>%sonata.exporter.writer.xml.child_element%</argument>
         </service>
-        <service id="sonata.exporter.exporter" class="Exporter\Exporter"/>
+        <service id="sonata.exporter.exporter" class="Exporter\Exporter" public="true"/>
     </services>
 </container>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/exporter/blob/1.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a hotfix..

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Made `sonata.exporter.exporter` service public
```

## Subject

This service needs to be public to use it with symfony 4.
