### PR TITLE
Provide autowiring for Exporter class

### DIFF
--- a/src/Bridge/Symfony/Resources/config/services.xml
+++ b/src/Bridge/Symfony/Resources/config/services.xml
@@ -22,5 +22,6 @@
             <argument>%sonata.exporter.writer.xml.child_element%</argument>
         </service>
         <service id="sonata.exporter.exporter" class="Exporter\Exporter" public="true"/>
+        <service id="Exporter\Exporter" alias="sonata.exporter.exporter"/>
     </services>
 </container>


### PR DESCRIPTION
I am targeting this branch, because `Exporter` class was not autowired.

Closes #244 

## Changelog

```markdown
### Fixed

Provide autowiring of `Exporter` class
```

## Subject

Add `sonata.exporter.exporter` alias of `Exporter` class and allow autowire to it.
