### PR TITLE
Add forward-compatibility layer

### DIFF
--- a/aliases/Bridge/Symfony/Bundle/SonataExporterBundle.php
+++ b/aliases/Bridge/Symfony/Bundle/SonataExporterBundle.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Exporter\Bridge\Symfony\Bundle;
+
+if (!class_exists('\Sonata\\'.__NAMESPACE__.'\SonataExporterBundle', false)) {
+    @trigger_error(
+        'The '.__NAMESPACE__.'\SonataExporterBundle class is deprecated since version 1.x and will be removed in 2.0.'
+        .' Use \Sonata\\'.__NAMESPACE__.'\SonataExporterBundle instead',
+        E_USER_DEPRECATED
+    );
+}
+
+class_alias(
+    '\Sonata\\'.__NAMESPACE__.'\SonataExporterBundle',
+    __NAMESPACE__.'\SonataExporterBundle'
+);
+
+if (false) {
+    final class SonataExporterBundle extends \Sonata\Exporter\Bridge\Symfony\Bundle\SonataExporterBundle
+    {
+    }
+}

--- a/aliases/Bridge/Symfony/DependencyInjection/Compiler/ExporterCompilerPass.php
+++ b/aliases/Bridge/Symfony/DependencyInjection/Compiler/ExporterCompilerPass.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Exporter\Bridge\Symfony\DependencyInjection\Compiler;
+
+if (!class_exists('\Sonata\\'.__NAMESPACE__.'\ExporterCompilerPass', false)) {
+    @trigger_error(
+        'The '.__NAMESPACE__.'\ExporterCompilerPass class is deprecated since version 1.x and will be removed in 2.0.'
+        .' Use \Sonata\\'.__NAMESPACE__.'\ExporterCompilerPass instead',
+        E_USER_DEPRECATED
+    );
+}
+
+class_alias(
+    '\Sonata\\'.__NAMESPACE__.'\ExporterCompilerPass',
+    __NAMESPACE__.'\ExporterCompilerPass'
+);
+
+if (false) {
+    /**
+     * @deprecated since version 1.x, to be removed in 2.0.
+     */
+    final class ExporterCompilerPass extends \Sonata\Exporter\Bridge\Symfony\DependencyInjection\Compiler\ExporterCompilerPass
+    {
+    }
+}

--- a/aliases/Bridge/Symfony/DependencyInjection/Configuration.php
+++ b/aliases/Bridge/Symfony/DependencyInjection/Configuration.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Exporter\Bridge\Symfony\DependencyInjection;
+
+if (!class_exists('\Sonata\\'.__NAMESPACE__.'\Configuration', false)) {
+    @trigger_error(
+        'The '.__NAMESPACE__.'\Configuration class is deprecated since version 1.x and will be removed in 2.0.'
+        .' Use \Sonata\\'.__NAMESPACE__.'\Configuration instead',
+        E_USER_DEPRECATED
+    );
+}
+
+class_alias(
+    '\Sonata\\'.__NAMESPACE__.'\Configuration',
+    __NAMESPACE__.'\Configuration'
+);
+
+if (false) {
+    final class Configuration extends \Sonata\Exporter\Bridge\Symfony\DependencyInjection\Configuration
+    {
+    }
+}

--- a/aliases/Bridge/Symfony/DependencyInjection/SonataExporterExtension.php
+++ b/aliases/Bridge/Symfony/DependencyInjection/SonataExporterExtension.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Exporter\Bridge\Symfony\DependencyInjection;
+
+if (!class_exists('\Sonata\\'.__NAMESPACE__.'\SonataExporterExtension', false)) {
+    @trigger_error(
+        'The '.__NAMESPACE__.'\SonataExporterExtension class is deprecated since version 1.x and will be removed in 2.0.'
+        .' Use \Sonata\\'.__NAMESPACE__.'\SonataExporterExtension instead',
+        E_USER_DEPRECATED
+    );
+}
+
+class_alias(
+    '\Sonata\\'.__NAMESPACE__.'\SonataExporterExtension',
+    __NAMESPACE__.'\SonataExporterExtension'
+);
+
+if (false) {
+    /**
+     * @deprecated since version 1.x, to be removed in 2.0.
+     */
+    final class SonataExporterExtension extends \Sonata\Exporter\Bridge\Symfony\DependencyInjection\SonataExporterExtension
+    {
+    }
+}

--- a/aliases/Exception/InvalidDataFormatException.php
+++ b/aliases/Exception/InvalidDataFormatException.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Exporter\Exception;
+
+if (!class_exists('\Sonata\\'.__NAMESPACE__.'\InvalidDataFormatException', false)) {
+    @trigger_error(
+        'The '.__NAMESPACE__.'\InvalidDataFormatException class is deprecated since version 1.x and will be removed in 2.0.'
+        .' Use \Sonata\\'.__NAMESPACE__.'\InvalidDataFormatException instead',
+        E_USER_DEPRECATED
+    );
+}
+
+class_alias(
+    '\Sonata\\'.__NAMESPACE__.'\InvalidDataFormatException',
+    __NAMESPACE__.'\InvalidDataFormatException'
+);
+
+if (false) {
+    class InvalidDataFormatException extends \Sonata\Exporter\Exception\InvalidDataFormatException
+    {
+    }
+}

--- a/aliases/Exception/InvalidMethodCallException.php
+++ b/aliases/Exception/InvalidMethodCallException.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Exporter\Exception;
+
+if (!class_exists('\Sonata\\'.__NAMESPACE__.'\InvalidMethodCallException', false)) {
+    @trigger_error(
+        'The '.__NAMESPACE__.'\InvalidMethodCallException class is deprecated since version 1.x and will be removed in 2.0.'
+        .' Use \Sonata\\'.__NAMESPACE__.'\InvalidMethodCallException instead',
+        E_USER_DEPRECATED
+    );
+}
+
+class_alias(
+    '\Sonata\\'.__NAMESPACE__.'\InvalidMethodCallException',
+    __NAMESPACE__.'\InvalidMethodCallException'
+);
+
+if (false) {
+    class InvalidMethodCallException extends \Sonata\Exporter\Exception\InvalidMethodCallException
+    {
+    }
+}

--- a/aliases/Exporter.php
+++ b/aliases/Exporter.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Exporter;
+
+if (!class_exists('\Sonata\\'.__NAMESPACE__.'\Exporter', false)) {
+    @trigger_error(
+        'The '.__NAMESPACE__.'\Exporter class is deprecated since version 1.x and will be removed in 2.0.'
+        .' Use \Sonata\\'.__NAMESPACE__.'\Exporter instead',
+        E_USER_DEPRECATED
+    );
+}
+
+class_alias(
+    '\Sonata\\'.__NAMESPACE__.'\Exporter',
+    __NAMESPACE__.'\Exporter'
+);
+
+if (false) {
+    /**
+     * @deprecated since version 1.x, to be removed in 2.0.
+     */
+    final class Exporter
+    {
+    }
+}

--- a/aliases/Handler.php
+++ b/aliases/Handler.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Exporter;
+
+if (!class_exists('\Sonata\\'.__NAMESPACE__.'\Handler', false)) {
+    @trigger_error(
+        'The '.__NAMESPACE__.'\Handler class is deprecated since version 1.x and will be removed in 2.0.'
+        .' Use \Sonata\\'.__NAMESPACE__.'\Handler instead',
+        E_USER_DEPRECATED
+    );
+}
+
+class_alias(
+    '\Sonata\\'.__NAMESPACE__.'\Handler',
+    __NAMESPACE__.'\Handler'
+);
+
+if (false) {
+    class Handler extends \Sonata\Exporter\Handler
+    {
+    }
+}

--- a/aliases/Source/AbstractXmlSourceIterator.php
+++ b/aliases/Source/AbstractXmlSourceIterator.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Exporter\Source;
+
+if (!class_exists('\Sonata\\'.__NAMESPACE__.'\AbstractXmlSourceIterator', false)) {
+    @trigger_error(
+        'The '.__NAMESPACE__.'\AbstractXmlSourceIterator class is deprecated since version 1.x and will be removed in 2.0.'
+        .' Use \Sonata\\'.__NAMESPACE__.'\AbstractXmlSourceIterator instead',
+        E_USER_DEPRECATED
+    );
+}
+
+class_alias(
+    '\Sonata\\'.__NAMESPACE__.'\AbstractXmlSourceIterator',
+    __NAMESPACE__.'\AbstractXmlSourceIterator'
+);
+
+if (false) {
+    abstract class AbstractXmlSourceIterator extends \Sonata\Exporter\Source\AbstractXmlSourceIterator
+    {
+    }
+}

--- a/aliases/Source/ArraySourceIterator.php
+++ b/aliases/Source/ArraySourceIterator.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Exporter\Source;
+
+if (!class_exists('\Sonata\\'.__NAMESPACE__.'\ArraySourceIterator', false)) {
+    @trigger_error(
+        'The '.__NAMESPACE__.'\ArraySourceIterator class is deprecated since version 1.x and will be removed in 2.0.'
+        .' Use \Sonata\\'.__NAMESPACE__.'\ArraySourceIterator instead',
+        E_USER_DEPRECATED
+    );
+}
+
+class_alias(
+    '\Sonata\\'.__NAMESPACE__.'\ArraySourceIterator',
+    __NAMESPACE__.'\ArraySourceIterator'
+);
+
+if (false) {
+    /**
+     * @deprecated since version 1.x, to be removed in 2.0.
+     */
+    class ArraySourceIterator extends \Sonata\Exporter\Source\ArraySourceIterator
+    {
+    }
+}

--- a/aliases/Source/ChainSourceIterator.php
+++ b/aliases/Source/ChainSourceIterator.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Exporter\Source;
+
+if (!class_exists('\Sonata\\'.__NAMESPACE__.'\ChainSourceIterator', false)) {
+    @trigger_error(
+        'The '.__NAMESPACE__.'\ChainSourceIterator class is deprecated since version 1.x and will be removed in 2.0.'
+        .' Use \Sonata\\'.__NAMESPACE__.'\ChainSourceIterator instead',
+        E_USER_DEPRECATED
+    );
+}
+
+class_alias(
+    '\Sonata\\'.__NAMESPACE__.'\ChainSourceIterator',
+    __NAMESPACE__.'\ChainSourceIterator'
+);
+
+if (false) {
+    class ChainSourceIterator extends \Sonata\Exporter\Source\ChainSourceIterator
+    {
+    }
+}

--- a/aliases/Source/CsvSourceIterator.php
+++ b/aliases/Source/CsvSourceIterator.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Exporter\Source;
+
+if (!class_exists('\Sonata\\'.__NAMESPACE__.'\CsvSourceIterator', false)) {
+    @trigger_error(
+        'The '.__NAMESPACE__.'\CsvSourceIterator class is deprecated since version 1.x and will be removed in 2.0.'
+        .' Use \Sonata\\'.__NAMESPACE__.'\CsvSourceIterator instead',
+        E_USER_DEPRECATED
+    );
+}
+
+class_alias(
+    '\Sonata\\'.__NAMESPACE__.'\CsvSourceIterator',
+    __NAMESPACE__.'\CsvSourceIterator'
+);
+
+if (false) {
+    class CsvSourceIterator extends \Sonata\Exporter\Source\CsvSourceIterator
+    {
+    }
+}

--- a/aliases/Source/DoctrineDBALConnectionSourceIterator.php
+++ b/aliases/Source/DoctrineDBALConnectionSourceIterator.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Exporter\Source;
+
+if (!class_exists('\Sonata\\'.__NAMESPACE__.'\DoctrineDBALConnectionSourceIterator', false)) {
+    @trigger_error(
+        'The '.__NAMESPACE__.'\DoctrineDBALConnectionSourceIterator class is deprecated since version 1.x and will be removed in 2.0.'
+        .' Use \Sonata\\'.__NAMESPACE__.'\DoctrineDBALConnectionSourceIterator instead',
+        E_USER_DEPRECATED
+    );
+}
+
+class_alias(
+    '\Sonata\\'.__NAMESPACE__.'\DoctrineDBALConnectionSourceIterator',
+    __NAMESPACE__.'\DoctrineDBALConnectionSourceIterator'
+);
+
+if (false) {
+    class DoctrineDBALConnectionSourceIterator extends \Sonata\Exporter\Source\DoctrineDBALConnectionSourceIterator
+    {
+    }
+}

--- a/aliases/Source/DoctrineODMQuerySourceIterator.php
+++ b/aliases/Source/DoctrineODMQuerySourceIterator.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Exporter\Source;
+
+if (!class_exists('\Sonata\\'.__NAMESPACE__.'\DoctrineODMQuerySourceIterator', false)) {
+    @trigger_error(
+        'The '.__NAMESPACE__.'\DoctrineODMQuerySourceIterator class is deprecated since version 1.x and will be removed in 2.0.'
+        .' Use \Sonata\\'.__NAMESPACE__.'\DoctrineODMQuerySourceIterator instead',
+        E_USER_DEPRECATED
+    );
+}
+
+class_alias(
+    '\Sonata\\'.__NAMESPACE__.'\DoctrineODMQuerySourceIterator',
+    __NAMESPACE__.'\DoctrineODMQuerySourceIterator'
+);
+
+if (false) {
+    class DoctrineODMQuerySourceIterator extends \Sonata\Exporter\Source\DoctrineODMQuerySourceIterator
+    {
+    }
+}

--- a/aliases/Source/DoctrineORMQuerySourceIterator.php
+++ b/aliases/Source/DoctrineORMQuerySourceIterator.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Exporter\Source;
+
+if (!class_exists('\Sonata\\'.__NAMESPACE__.'\DoctrineORMQuerySourceIterator', false)) {
+    @trigger_error(
+        'The '.__NAMESPACE__.'\DoctrineORMQuerySourceIterator class is deprecated since version 1.x and will be removed in 2.0.'
+        .' Use \Sonata\\'.__NAMESPACE__.'\DoctrineORMQuerySourceIterator instead',
+        E_USER_DEPRECATED
+    );
+}
+
+class_alias(
+    '\Sonata\\'.__NAMESPACE__.'\DoctrineORMQuerySourceIterator',
+    __NAMESPACE__.'\DoctrineORMQuerySourceIterator'
+);
+
+if (false) {
+    class DoctrineORMQuerySourceIterator extends \Sonata\Exporter\Source\DoctrineORMQuerySourceIterator
+    {
+    }
+}

--- a/aliases/Source/IteratorCallbackSourceIterator.php
+++ b/aliases/Source/IteratorCallbackSourceIterator.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Exporter\Source;
+
+if (!class_exists('\Sonata\\'.__NAMESPACE__.'\IteratorCallbackSourceIterator', false)) {
+    @trigger_error(
+        'The '.__NAMESPACE__.'\IteratorCallbackSourceIterator class is deprecated since version 1.x and will be removed in 2.0.'
+        .' Use \Sonata\\'.__NAMESPACE__.'\IteratorCallbackSourceIterator instead',
+        E_USER_DEPRECATED
+    );
+}
+
+class_alias(
+    '\Sonata\\'.__NAMESPACE__.'\IteratorCallbackSourceIterator',
+    __NAMESPACE__.'\IteratorCallbackSourceIterator'
+);
+
+if (false) {
+    class IteratorCallbackSourceIterator extends \Sonata\Exporter\Source\IteratorCallbackSourceIterator
+    {
+    }
+}

--- a/aliases/Source/IteratorSourceIterator.php
+++ b/aliases/Source/IteratorSourceIterator.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Exporter\Source;
+
+if (!class_exists('\Sonata\\'.__NAMESPACE__.'\IteratorSourceIterator', false)) {
+    @trigger_error(
+        'The '.__NAMESPACE__.'\IteratorSourceIterator class is deprecated since version 1.x and will be removed in 2.0.'
+        .' Use \Sonata\\'.__NAMESPACE__.'\IteratorSourceIterator instead',
+        E_USER_DEPRECATED
+    );
+}
+
+class_alias(
+    '\Sonata\\'.__NAMESPACE__.'\IteratorSourceIterator',
+    __NAMESPACE__.'\IteratorSourceIterator'
+);
+
+if (false) {
+    /**
+     * @deprecated since version 1.x, to be removed in 2.0.
+     */
+    class IteratorSourceIterator extends \Sonata\Exporter\Source\IteratorSourceIterator
+    {
+    }
+}

--- a/aliases/Source/PDOStatementSourceIterator.php
+++ b/aliases/Source/PDOStatementSourceIterator.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Exporter\Source;
+
+if (!class_exists('\Sonata\\'.__NAMESPACE__.'\PDOStatementSourceIterator', false)) {
+    @trigger_error(
+        'The '.__NAMESPACE__.'\PDOStatementSourceIterator class is deprecated since version 1.x and will be removed in 2.0.'
+        .' Use \Sonata\\'.__NAMESPACE__.'\PDOStatementSourceIterator instead',
+        E_USER_DEPRECATED
+    );
+}
+
+class_alias(
+    '\Sonata\\'.__NAMESPACE__.'\PDOStatementSourceIterator',
+    __NAMESPACE__.'\PDOStatementSourceIterator'
+);
+
+if (false) {
+    class PDOStatementSourceIterator extends \Sonata\Exporter\Source\PDOStatementSourceIterator
+    {
+    }
+}

--- a/aliases/Source/PropelCollectionSourceIterator.php
+++ b/aliases/Source/PropelCollectionSourceIterator.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Exporter\Source;
+
+if (!class_exists('\Sonata\\'.__NAMESPACE__.'\PropelCollectionSourceIterator', false)) {
+    @trigger_error(
+        'The '.__NAMESPACE__.'\PropelCollectionSourceIterator class is deprecated since version 1.x and will be removed in 2.0.'
+        .' Use \Sonata\\'.__NAMESPACE__.'\PropelCollectionSourceIterator instead',
+        E_USER_DEPRECATED
+    );
+}
+
+class_alias(
+    '\Sonata\\'.__NAMESPACE__.'\PropelCollectionSourceIterator',
+    __NAMESPACE__.'\PropelCollectionSourceIterator'
+);
+
+if (false) {
+    class PropelCollectionSourceIterator extends \Sonata\Exporter\Source\PropelCollectionSourceIterator
+    {
+    }
+}

--- a/aliases/Source/SourceIteratorInterface.php
+++ b/aliases/Source/SourceIteratorInterface.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Exporter\Source;
+
+if (!interface_exists('\Sonata\\'.__NAMESPACE__.'\SourceIteratorInterface', false)) {
+    @trigger_error(
+        'The '.__NAMESPACE__.'\SourceIteratorInterface class is deprecated since version 1.x and will be removed in 2.0.'
+        .' Use \Sonata\\'.__NAMESPACE__.'\SourceIteratorInterface instead',
+        E_USER_DEPRECATED
+    );
+}
+
+class_alias(
+    '\Sonata\\'.__NAMESPACE__.'\SourceIteratorInterface',
+    __NAMESPACE__.'\SourceIteratorInterface'
+);
+
+if (false) {
+    /**
+     * @deprecated since version 1.x, to be removed in 2.0.
+     */
+    interface SourceIteratorInterface extends \Sonata\Exporter\Source\SourceIteratorInterface
+    {
+    }
+}

--- a/aliases/Source/SymfonySitemapSourceIterator.php
+++ b/aliases/Source/SymfonySitemapSourceIterator.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Exporter\Source;
+
+if (!class_exists('\Sonata\\'.__NAMESPACE__.'\SymfonySitemapSourceIterator', false)) {
+    @trigger_error(
+        'The '.__NAMESPACE__.'\SymfonySitemapSourceIterator class is deprecated since version 1.x and will be removed in 2.0.'
+        .' Use \Sonata\\'.__NAMESPACE__.'\SymfonySitemapSourceIterator instead',
+        E_USER_DEPRECATED
+    );
+}
+
+class_alias(
+    '\Sonata\\'.__NAMESPACE__.'\SymfonySitemapSourceIterator',
+    __NAMESPACE__.'\SymfonySitemapSourceIterator'
+);
+
+if (false) {
+    class SymfonySitemapSourceIterator extends \Sonata\Exporter\Source\SymfonySitemapSourceIterator
+    {
+    }
+}

--- a/aliases/Source/XmlExcelSourceIterator.php
+++ b/aliases/Source/XmlExcelSourceIterator.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Exporter\Source;
+
+if (!class_exists('\Sonata\\'.__NAMESPACE__.'\XmlExcelSourceIterator', false)) {
+    @trigger_error(
+        'The '.__NAMESPACE__.'\XmlExcelSourceIterator class is deprecated since version 1.x and will be removed in 2.0.'
+        .' Use \Sonata\\'.__NAMESPACE__.'\XmlExcelSourceIterator instead',
+        E_USER_DEPRECATED
+    );
+}
+
+class_alias(
+    '\Sonata\\'.__NAMESPACE__.'\XmlExcelSourceIterator',
+    __NAMESPACE__.'\XmlExcelSourceIterator'
+);
+
+if (false) {
+    class XmlExcelSourceIterator extends \Sonata\Exporter\Source\XmlExcelSourceIterator
+    {
+    }
+}

--- a/aliases/Source/XmlSourceIterator.php
+++ b/aliases/Source/XmlSourceIterator.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Exporter\Source;
+
+if (!class_exists('\Sonata\\'.__NAMESPACE__.'\XmlSourceIterator', false)) {
+    @trigger_error(
+        'The '.__NAMESPACE__.'\XmlSourceIterator class is deprecated since version 1.x and will be removed in 2.0.'
+        .' Use \Sonata\\'.__NAMESPACE__.'\XmlSourceIterator instead',
+        E_USER_DEPRECATED
+    );
+}
+
+class_alias(
+    '\Sonata\\'.__NAMESPACE__.'\XmlSourceIterator',
+    __NAMESPACE__.'\XmlSourceIterator'
+);
+
+if (false) {
+    class XmlSourceIterator extends \Sonata\Exporter\Source\XmlSourceIterator
+    {
+    }
+}

--- a/aliases/Test/AbstractTypedWriterTestCase.php
+++ b/aliases/Test/AbstractTypedWriterTestCase.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Exporter\Test;
+
+if (!class_exists('\Sonata\\'.__NAMESPACE__.'\AbstractTypedWriterTestCase', false)) {
+    @trigger_error(
+        'The '.__NAMESPACE__.'\AbstractTypedWriterTestCase class is deprecated since version 1.x and will be removed in 2.0.'
+        .' Use \Sonata\\'.__NAMESPACE__.'\AbstractTypedWriterTestCase instead',
+        E_USER_DEPRECATED
+    );
+}
+
+class_alias(
+    '\Sonata\\'.__NAMESPACE__.'\AbstractTypedWriterTestCase',
+    __NAMESPACE__.'\AbstractTypedWriterTestCase'
+);
+
+if (false) {
+    /**
+     * @deprecated since version 1.x, to be removed in 2.0.
+     */
+    abstract class AbstractTypedWriterTestCase extends \Sonata\Exporter\Test\AbstractTypedWriterTestCase
+    {
+    }
+}

--- a/aliases/Writer/CsvWriter.php
+++ b/aliases/Writer/CsvWriter.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Exporter\Writer;
+
+if (!class_exists('\Sonata\\'.__NAMESPACE__.'\CsvWriter', false)) {
+    @trigger_error(
+        'The '.__NAMESPACE__.'\CsvWriter class is deprecated since version 1.x and will be removed in 2.0.'
+        .' Use \Sonata\\'.__NAMESPACE__.'\CsvWriter instead',
+        E_USER_DEPRECATED
+    );
+}
+
+class_alias(
+    '\Sonata\\'.__NAMESPACE__.'\CsvWriter',
+    __NAMESPACE__.'\CsvWriter'
+);
+
+if (false) {
+    class CsvWriter extends \Sonata\Exporter\Writer\CsvWriter
+    {
+    }
+}

--- a/aliases/Writer/CsvWriterTerminate.php
+++ b/aliases/Writer/CsvWriterTerminate.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Exporter\Writer;
+
+if (!class_exists('\Sonata\\'.__NAMESPACE__.'\CsvWriterTerminate', false)) {
+    @trigger_error(
+        'The '.__NAMESPACE__.'\CsvWriterTerminate class is deprecated since version 1.x and will be removed in 2.0.'
+        .' Use \Sonata\\'.__NAMESPACE__.'\CsvWriterTerminate instead',
+        E_USER_DEPRECATED
+    );
+}
+
+class_alias(
+    '\Sonata\\'.__NAMESPACE__.'\CsvWriterTerminate',
+    __NAMESPACE__.'\CsvWriterTerminate'
+);
+
+if (false) {
+    final class CsvWriterTerminate extends \Sonata\Exporter\Writer\CsvWriterTerminate
+    {
+    }
+}

--- a/aliases/Writer/FormattedBoolWriter.php
+++ b/aliases/Writer/FormattedBoolWriter.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Exporter\Writer;
+
+if (!class_exists('\Sonata\\'.__NAMESPACE__.'\FormattedBoolWriter', false)) {
+    @trigger_error(
+        'The '.__NAMESPACE__.'\FormattedBoolWriter class is deprecated since version 1.x and will be removed in 2.0.'
+        .' Use \Sonata\\'.__NAMESPACE__.'\FormattedBoolWriter instead',
+        E_USER_DEPRECATED
+    );
+}
+class_alias(
+    '\Sonata\\'.__NAMESPACE__.'\FormattedBoolWriter',
+    __NAMESPACE__.'\FormattedBoolWriter'
+);
+
+if (false) {
+    class FormattedBoolWriter extends \Sonata\Exporter\Writer\FormattedBoolWriter
+    {
+    }
+}

--- a/aliases/Writer/GsaFeedWriter.php
+++ b/aliases/Writer/GsaFeedWriter.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Exporter\Writer;
+
+if (!class_exists('\Sonata\\'.__NAMESPACE__.'\GsaFeedWriter', false)) {
+    @trigger_error(
+        'The '.__NAMESPACE__.'\GsaFeedWriter class is deprecated since version 1.x and will be removed in 2.0.'
+        .' Use \Sonata\\'.__NAMESPACE__.'\GsaFeedWriter instead',
+        E_USER_DEPRECATED
+    );
+}
+
+class_alias(
+    '\Sonata\\'.__NAMESPACE__.'\GsaFeedWriter',
+    __NAMESPACE__.'\GsaFeedWriter'
+);
+
+if (false) {
+    class GsaFeedWriter extends \Sonata\Exporter\Writer\GsaFeedWriter
+    {
+    }
+}

--- a/aliases/Writer/InMemoryWriter.php
+++ b/aliases/Writer/InMemoryWriter.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Exporter\Writer;
+
+if (!class_exists('\Sonata\\'.__NAMESPACE__.'\InMemoryWriter', false)) {
+    @trigger_error(
+        'The '.__NAMESPACE__.'\InMemoryWriter class is deprecated since version 1.x and will be removed in 2.0.'
+        .' Use \Sonata\\'.__NAMESPACE__.'\InMemoryWriter instead',
+        E_USER_DEPRECATED
+    );
+}
+
+class_alias(
+    '\Sonata\\'.__NAMESPACE__.'\InMemoryWriter',
+    __NAMESPACE__.'\InMemoryWriter'
+);
+
+if (false) {
+    class InMemoryWriter extends \Sonata\Exporter\Writer\InMemoryWriter
+    {
+    }
+}

--- a/aliases/Writer/JsonWriter.php
+++ b/aliases/Writer/JsonWriter.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Exporter\Writer;
+
+if (!class_exists('\Sonata\\'.__NAMESPACE__.'\JsonWriter', false)) {
+    @trigger_error(
+        'The '.__NAMESPACE__.'\JsonWriter class is deprecated since version 1.x and will be removed in 2.0.'
+        .' Use \Sonata\\'.__NAMESPACE__.'\JsonWriter instead',
+        E_USER_DEPRECATED
+    );
+}
+
+class_alias(
+    '\Sonata\\'.__NAMESPACE__.'\JsonWriter',
+    __NAMESPACE__.'\JsonWriter'
+);
+
+if (false) {
+    class JsonWriter extends \Sonata\Exporter\Writer\JsonWriter
+    {
+    }
+}

--- a/aliases/Writer/SitemapWriter.php
+++ b/aliases/Writer/SitemapWriter.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Exporter\Writer;
+
+if (!class_exists('\Sonata\\'.__NAMESPACE__.'\SitemapWriter', false)) {
+    @trigger_error(
+        'The '.__NAMESPACE__.'\SitemapWriter class is deprecated since version 1.x and will be removed in 2.0.'
+        .' Use \Sonata\\'.__NAMESPACE__.'\SitemapWriter instead',
+        E_USER_DEPRECATED
+    );
+}
+
+class_alias(
+    '\Sonata\\'.__NAMESPACE__.'\SitemapWriter',
+    __NAMESPACE__.'\SitemapWriter'
+);
+
+if (false) {
+    class SitemapWriter extends \Sonata\Exporter\Writer\SitemapWriter
+    {
+    }
+}

--- a/aliases/Writer/TypedWriterInterface.php
+++ b/aliases/Writer/TypedWriterInterface.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Exporter\Writer;
+
+if (!interface_exists('\Sonata\\'.__NAMESPACE__.'\TypedWriterInterface', false)) {
+    @trigger_error(
+        'The '.__NAMESPACE__.'\TypedWriterInterface class is deprecated since version 1.x and will be removed in 2.0.'
+        .' Use \Sonata\\'.__NAMESPACE__.'\TypedWriterInterface instead',
+        E_USER_DEPRECATED
+    );
+}
+
+class_alias(
+    '\Sonata\\'.__NAMESPACE__.'\TypedWriterInterface',
+    __NAMESPACE__.'\TypedWriterInterface'
+);
+
+if (false) {
+    /**
+     * @deprecated since version 1.x, to be removed in 2.0.
+     */
+    interface TypedWriterInterface extends \Sonata\Exporter\Writer\TypedWriterInterface
+    {
+    }
+}

--- a/aliases/Writer/WriterInterface.php
+++ b/aliases/Writer/WriterInterface.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Exporter\Writer;
+
+if (!interface_exists('\Sonata\\'.__NAMESPACE__.'\WriterInterface', false)) {
+    @trigger_error(
+        'The '.__NAMESPACE__.'\WriterInterface class is deprecated since version 1.x and will be removed in 2.0.'
+        .' Use \Sonata\\'.__NAMESPACE__.'\WriterInterface instead',
+        E_USER_DEPRECATED
+    );
+}
+
+class_alias(
+    '\Sonata\\'.__NAMESPACE__.'\WriterInterface',
+    __NAMESPACE__.'\WriterInterface'
+);
+
+if (false) {
+    /**
+     * @deprecated since version 1.x, to be removed in 2.0.
+     */
+    interface WriterInterface extends Exporter\Writer
+    {
+    }
+}

--- a/aliases/Writer/XlsWriter.php
+++ b/aliases/Writer/XlsWriter.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Exporter\Writer;
+
+if (!class_exists('\Sonata\\'.__NAMESPACE__.'\XlsWriter', false)) {
+    @trigger_error(
+        'The '.__NAMESPACE__.'\XlsWriter class is deprecated since version 1.x and will be removed in 2.0.'
+        .' Use \Sonata\\'.__NAMESPACE__.'\XlsWriter instead',
+        E_USER_DEPRECATED
+    );
+}
+
+class_alias(
+    '\Sonata\\'.__NAMESPACE__.'\XlsWriter',
+    __NAMESPACE__.'\XlsWriter'
+);
+
+if (false) {
+    class XlsWriter extends \Sonata\Exporter\Writer\XlsWriter
+    {
+    }
+}

--- a/aliases/Writer/XmlExcelWriter.php
+++ b/aliases/Writer/XmlExcelWriter.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Exporter\Writer;
+
+if (!class_exists('\Sonata\\'.__NAMESPACE__.'\XmlExcelWriter', false)) {
+    @trigger_error(
+        'The '.__NAMESPACE__.'\XmlExcelWriter class is deprecated since version 1.x and will be removed in 2.0.'
+        .' Use \Sonata\\'.__NAMESPACE__.'\XmlExcelWriter instead',
+        E_USER_DEPRECATED
+    );
+}
+
+class_alias(
+    '\Sonata\\'.__NAMESPACE__.'\XmlExcelWriter',
+    __NAMESPACE__.'\XmlExcelWriter'
+);
+
+if (false) {
+    class XmlExcelWriter extends \Sonata\Exporter\Writer\XmlExcelWriter
+    {
+    }
+}

--- a/aliases/Writer/XmlWriter.php
+++ b/aliases/Writer/XmlWriter.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Exporter\Writer;
+
+if (!class_exists('\Sonata\\'.__NAMESPACE__.'\XmlWriter', false)) {
+    @trigger_error(
+        'The '.__NAMESPACE__.'\XmlWriter class is deprecated since version 1.x and will be removed in 2.0.'
+        .' Use \Sonata\\'.__NAMESPACE__.'\XmlWriter instead',
+        E_USER_DEPRECATED
+    );
+}
+
+class_alias(
+    '\Sonata\\'.__NAMESPACE__.'\XmlWriter',
+    __NAMESPACE__.'\XmlWriter'
+);
+
+if (false) {
+    class XmlWriter extends \Sonata\Exporter\Writer\XmlWriter
+    {
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,8 @@
     },
     "autoload": {
         "psr-4": {
-            "Exporter\\": "src/"
+            "Exporter\\": "aliases/",
+            "Sonata\\Exporter\\": "src/"
         }
     },
     "autoload-dev": {

--- a/src/Bridge/Symfony/Bundle/SonataExporterBundle.php
+++ b/src/Bridge/Symfony/Bundle/SonataExporterBundle.php
@@ -9,9 +9,9 @@
  * file that was distributed with this source code.
  */
 
-namespace Exporter\Bridge\Symfony\Bundle;
+namespace Sonata\Exporter\Bridge\Symfony\Bundle;
 
-use Exporter\Bridge\Symfony\DependencyInjection\Compiler\ExporterCompilerPass;
+use Sonata\Exporter\Bridge\Symfony\DependencyInjection\Compiler\ExporterCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -33,3 +33,5 @@ final class SonataExporterBundle extends Bundle
         return 'Exporter\Bridge\Symfony\DependencyInjection\SonataExporterExtension';
     }
 }
+
+class_exists(\Exporter\Bridge\Symfony\Bundle\SonataExporterBundle::class);

--- a/src/Bridge/Symfony/DependencyInjection/Compiler/ExporterCompilerPass.php
+++ b/src/Bridge/Symfony/DependencyInjection/Compiler/ExporterCompilerPass.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Exporter\Bridge\Symfony\DependencyInjection\Compiler;
+namespace Sonata\Exporter\Bridge\Symfony\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -37,3 +37,5 @@ final class ExporterCompilerPass implements CompilerPassInterface
         }
     }
 }
+
+class_exists(\Exporter\Bridge\Symfony\DependencyInjection\Compiler\ExporterCompilerPass::class);

--- a/src/Bridge/Symfony/DependencyInjection/Configuration.php
+++ b/src/Bridge/Symfony/DependencyInjection/Configuration.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Exporter\Bridge\Symfony\DependencyInjection;
+namespace Sonata\Exporter\Bridge\Symfony\DependencyInjection;
 
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
@@ -123,3 +123,5 @@ final class Configuration implements ConfigurationInterface
         return $treeBuilder;
     }
 }
+
+class_exists(\Exporter\Bridge\Symfony\DependencyInjection\Configuration::class);

--- a/src/Bridge/Symfony/DependencyInjection/SonataExporterExtension.php
+++ b/src/Bridge/Symfony/DependencyInjection/SonataExporterExtension.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Exporter\Bridge\Symfony\DependencyInjection;
+namespace Sonata\Exporter\Bridge\Symfony\DependencyInjection;
 
 use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\Config\FileLocator;
@@ -62,3 +62,5 @@ final class SonataExporterExtension extends Extension
         }
     }
 }
+
+class_exists(\Exporter\Bridge\Symfony\DependencyInjection\SonataExporterExtension::class);

--- a/src/Exception/InvalidDataFormatException.php
+++ b/src/Exception/InvalidDataFormatException.php
@@ -9,8 +9,10 @@
  * file that was distributed with this source code.
  */
 
-namespace Exporter\Exception;
+namespace Sonata\Exporter\Exception;
 
 class InvalidDataFormatException extends \RuntimeException
 {
 }
+
+class_exists(\Exporter\Exception\InvalidDataFormatException::class);

--- a/src/Exception/InvalidMethodCallException.php
+++ b/src/Exception/InvalidMethodCallException.php
@@ -9,8 +9,10 @@
  * file that was distributed with this source code.
  */
 
-namespace Exporter\Exception;
+namespace Sonata\Exporter\Exception;
 
 class InvalidMethodCallException extends \RuntimeException
 {
 }
+
+class_exists(\Exporter\Exception\InvalidMethodCallException::class);

--- a/src/Exporter.php
+++ b/src/Exporter.php
@@ -9,10 +9,10 @@
  * file that was distributed with this source code.
  */
 
-namespace Exporter;
+namespace Sonata\Exporter;
 
-use Exporter\Source\SourceIteratorInterface;
-use Exporter\Writer\TypedWriterInterface;
+use Sonata\Exporter\Source\SourceIteratorInterface;
+use Sonata\Exporter\Writer\TypedWriterInterface;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
 /**
@@ -91,3 +91,5 @@ final class Exporter
         $this->writers[$writer->getFormat()] = $writer;
     }
 }
+
+class_exists(\Exporter\Exporter::class);

--- a/src/Handler.php
+++ b/src/Handler.php
@@ -9,10 +9,10 @@
  * file that was distributed with this source code.
  */
 
-namespace Exporter;
+namespace Sonata\Exporter;
 
-use Exporter\Source\SourceIteratorInterface;
-use Exporter\Writer\WriterInterface;
+use Sonata\Exporter\Source\SourceIteratorInterface;
+use Sonata\Exporter\Writer\WriterInterface;
 
 class Handler
 {
@@ -58,3 +58,5 @@ class Handler
         return new self($source, $writer);
     }
 }
+
+class_exists(\Exporter\Handler::class);

--- a/src/Source/AbstractXmlSourceIterator.php
+++ b/src/Source/AbstractXmlSourceIterator.php
@@ -146,7 +146,7 @@ abstract class AbstractXmlSourceIterator implements SourceIteratorInterface
         xml_parser_set_option($this->parser, XML_OPTION_CASE_FOLDING, 0);
         xml_parser_set_option($this->parser, XML_OPTION_SKIP_WHITE, 0);
 
-        $this->file = fopen($this->filename, 'rb');
+        $this->file = fopen($this->filename, 'r');
 
         $this->bufferedRow = [];
         $this->currentRowIndex = 0;

--- a/src/Source/AbstractXmlSourceIterator.php
+++ b/src/Source/AbstractXmlSourceIterator.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Exporter\Source;
+namespace Sonata\Exporter\Source;
 
 /**
  * Read data from a Xml file.
@@ -217,3 +217,5 @@ abstract class AbstractXmlSourceIterator implements SourceIteratorInterface
         }
     }
 }
+
+class_exists(\Exporter\Source\AbstractXmlSourceIterator::class);

--- a/src/Source/ArraySourceIterator.php
+++ b/src/Source/ArraySourceIterator.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Exporter\Source;
+namespace Sonata\Exporter\Source;
 
 class ArraySourceIterator extends IteratorSourceIterator
 {
@@ -21,3 +21,5 @@ class ArraySourceIterator extends IteratorSourceIterator
         parent::__construct(new \ArrayIterator($data));
     }
 }
+
+class_exists(\Exporter\Source\ArraySourceIterator::class);

--- a/src/Source/ChainSourceIterator.php
+++ b/src/Source/ChainSourceIterator.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Exporter\Source;
+namespace Sonata\Exporter\Source;
 
 use ArrayIterator;
 
@@ -92,3 +92,5 @@ class ChainSourceIterator implements SourceIteratorInterface
         }
     }
 }
+
+class_exists(\Exporter\Source\ChainSourceIterator::class);

--- a/src/Source/CsvSourceIterator.php
+++ b/src/Source/CsvSourceIterator.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Exporter\Source;
+namespace Sonata\Exporter\Source;
 
 /**
  * Read data from a csv file.
@@ -155,3 +155,5 @@ class CsvSourceIterator implements SourceIteratorInterface
         return true;
     }
 }
+
+class_exists(\Exporter\Source\CsvSourceIterator::class);

--- a/src/Source/CsvSourceIterator.php
+++ b/src/Source/CsvSourceIterator.php
@@ -122,7 +122,7 @@ class CsvSourceIterator implements SourceIteratorInterface
      */
     public function rewind()
     {
-        $this->file = fopen($this->filename, 'rb');
+        $this->file = fopen($this->filename, 'r');
         $this->position = 0;
         $line = fgetcsv($this->file, 0, $this->delimiter, $this->enclosure, $this->escape);
         if ($this->hasHeaders) {

--- a/src/Source/DoctrineDBALConnectionSourceIterator.php
+++ b/src/Source/DoctrineDBALConnectionSourceIterator.php
@@ -9,11 +9,11 @@
  * file that was distributed with this source code.
  */
 
-namespace Exporter\Source;
+namespace Sonata\Exporter\Source;
 
 use Doctrine\DBAL\Driver\Connection;
 use Doctrine\DBAL\Driver\Statement;
-use Exporter\Exception\InvalidMethodCallException;
+use Sonata\Exporter\Exception\InvalidMethodCallException;
 
 class DoctrineDBALConnectionSourceIterator implements SourceIteratorInterface
 {
@@ -109,3 +109,5 @@ class DoctrineDBALConnectionSourceIterator implements SourceIteratorInterface
         $this->next();
     }
 }
+
+class_exists(\Exporter\Source\DoctrineDBALConnectionSourceIterator::class);

--- a/src/Source/DoctrineODMQuerySourceIterator.php
+++ b/src/Source/DoctrineODMQuerySourceIterator.php
@@ -9,11 +9,11 @@
  * file that was distributed with this source code.
  */
 
-namespace Exporter\Source;
+namespace Sonata\Exporter\Source;
 
 use Doctrine\ODM\MongoDB\Query\Query;
 use Doctrine\ORM\Internal\Hydration\IterableResult;
-use Exporter\Exception\InvalidMethodCallException;
+use Sonata\Exporter\Exception\InvalidMethodCallException;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyPath;
 
@@ -156,3 +156,5 @@ class DoctrineODMQuerySourceIterator implements SourceIteratorInterface
         return $value;
     }
 }
+
+class_exists(\Exporter\Source\DoctrineODMQuerySourceIterator::class);

--- a/src/Source/DoctrineODMQuerySourceIterator.php
+++ b/src/Source/DoctrineODMQuerySourceIterator.php
@@ -141,7 +141,7 @@ class DoctrineODMQuerySourceIterator implements SourceIteratorInterface
     /**
      * @param $value
      *
-     * @return null|string
+     * @return string|null
      */
     protected function getValue($value)
     {

--- a/src/Source/DoctrineORMQuerySourceIterator.php
+++ b/src/Source/DoctrineORMQuerySourceIterator.php
@@ -189,7 +189,7 @@ class DoctrineORMQuerySourceIterator implements SourceIteratorInterface
     /**
      * @param $value
      *
-     * @return null|string
+     * @return string|null
      */
     protected function getValue($value)
     {

--- a/src/Source/DoctrineORMQuerySourceIterator.php
+++ b/src/Source/DoctrineORMQuerySourceIterator.php
@@ -9,10 +9,10 @@
  * file that was distributed with this source code.
  */
 
-namespace Exporter\Source;
+namespace Sonata\Exporter\Source;
 
 use Doctrine\ORM\Query;
-use Exporter\Exception\InvalidMethodCallException;
+use Sonata\Exporter\Exception\InvalidMethodCallException;
 use Symfony\Component\PropertyAccess\Exception\UnexpectedTypeException;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessor;
@@ -206,3 +206,5 @@ class DoctrineORMQuerySourceIterator implements SourceIteratorInterface
         return $value;
     }
 }
+
+class_exists(\Exporter\Source\DoctrineORMQuerySourceIterator::class);

--- a/src/Source/IteratorCallbackSourceIterator.php
+++ b/src/Source/IteratorCallbackSourceIterator.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Exporter\Source;
+namespace Sonata\Exporter\Source;
 
 /**
  * IteratorCallbackSource is IteratorSource with callback executed each row.
@@ -42,3 +42,5 @@ class IteratorCallbackSourceIterator extends IteratorSourceIterator
         return \call_user_func($this->transformer, $this->iterator->current());
     }
 }
+
+class_exists(\Exporter\Source\IteratorCallbackSourceIterator::class);

--- a/src/Source/IteratorSourceIterator.php
+++ b/src/Source/IteratorSourceIterator.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Exporter\Source;
+namespace Sonata\Exporter\Source;
 
 /**
  * SourceIterator implementation based on Iterator.
@@ -77,3 +77,5 @@ class IteratorSourceIterator implements SourceIteratorInterface
         $this->iterator->rewind();
     }
 }
+
+class_exists(\Exporter\Source\IteratorSourceIterator::class);

--- a/src/Source/PDOStatementSourceIterator.php
+++ b/src/Source/PDOStatementSourceIterator.php
@@ -9,9 +9,9 @@
  * file that was distributed with this source code.
  */
 
-namespace Exporter\Source;
+namespace Sonata\Exporter\Source;
 
-use Exporter\Exception\InvalidMethodCallException;
+use Sonata\Exporter\Exception\InvalidMethodCallException;
 
 class PDOStatementSourceIterator implements SourceIteratorInterface
 {
@@ -91,3 +91,5 @@ class PDOStatementSourceIterator implements SourceIteratorInterface
         $this->rewinded = true;
     }
 }
+
+class_exists(\Exporter\Source\PDOStatementSourceIterator::class);

--- a/src/Source/PropelCollectionSourceIterator.php
+++ b/src/Source/PropelCollectionSourceIterator.php
@@ -144,7 +144,7 @@ class PropelCollectionSourceIterator implements SourceIteratorInterface
     /**
      * @param $value
      *
-     * @return null|string
+     * @return string|null
      */
     protected function getValue($value)
     {

--- a/src/Source/PropelCollectionSourceIterator.php
+++ b/src/Source/PropelCollectionSourceIterator.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Exporter\Source;
+namespace Sonata\Exporter\Source;
 
 use PropelCollection;
 use Symfony\Component\PropertyAccess\PropertyAccess;
@@ -159,3 +159,5 @@ class PropelCollectionSourceIterator implements SourceIteratorInterface
         return $value;
     }
 }
+
+class_exists(\Exporter\Source\PropelCollectionSourceIterator::class);

--- a/src/Source/SourceIteratorInterface.php
+++ b/src/Source/SourceIteratorInterface.php
@@ -9,8 +9,10 @@
  * file that was distributed with this source code.
  */
 
-namespace Exporter\Source;
+namespace Sonata\Exporter\Source;
 
 interface SourceIteratorInterface extends \Iterator
 {
 }
+
+interface_exists(\Exporter\Source\SourceIteratorInterface::class);

--- a/src/Source/SymfonySitemapSourceIterator.php
+++ b/src/Source/SymfonySitemapSourceIterator.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Exporter\Source;
+namespace Sonata\Exporter\Source;
 
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\RouterInterface;
@@ -98,3 +98,5 @@ class SymfonySitemapSourceIterator implements SourceIteratorInterface
         $this->source->rewind();
     }
 }
+
+class_exists(\Exporter\Source\SymfonySitemapSourceIterator::class);

--- a/src/Source/XmlExcelSourceIterator.php
+++ b/src/Source/XmlExcelSourceIterator.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Exporter\Source;
+namespace Sonata\Exporter\Source;
 
 /**
  * Read data from a Xml Excel file.
@@ -76,3 +76,5 @@ class XmlExcelSourceIterator extends AbstractXmlSourceIterator
         $this->bufferedRow['i_'.$this->currentRowIndex][$this->currentColumnIndex] .= $data;
     }
 }
+
+class_exists(\Exporter\Source\XmlExcelSourceIterator::class);

--- a/src/Source/XmlSourceIterator.php
+++ b/src/Source/XmlSourceIterator.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Exporter\Source;
+namespace Sonata\Exporter\Source;
 
 /**
  * Read data from a Xml file.
@@ -110,3 +110,5 @@ class XmlSourceIterator extends AbstractXmlSourceIterator
         }
     }
 }
+
+class_exists(\Exporter\Source\XmlSourceIterator::class);

--- a/src/Test/AbstractTypedWriterTestCase.php
+++ b/src/Test/AbstractTypedWriterTestCase.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Exporter\Test;
+namespace Sonata\Exporter\Test;
 
 /**
  * @author Grégoire Paris <postmaster@greg0ire.fr>
@@ -44,3 +44,5 @@ abstract class AbstractTypedWriterTestCase extends \PHPUnit\Framework\TestCase
      */
     abstract protected function getWriter();
 }
+
+class_exists(\Exporter\Test\AbstractTypedWriterTestCase::class);

--- a/src/Writer/CsvWriter.php
+++ b/src/Writer/CsvWriter.php
@@ -9,9 +9,9 @@
  * file that was distributed with this source code.
  */
 
-namespace Exporter\Writer;
+namespace Sonata\Exporter\Writer;
 
-use Exporter\Exception\InvalidDataFormatException;
+use Sonata\Exporter\Exception\InvalidDataFormatException;
 
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
@@ -167,3 +167,5 @@ class CsvWriter implements TypedWriterInterface
         fputcsv($this->file, $headers, $this->delimiter, $this->enclosure, $this->escape);
     }
 }
+
+class_exists(\Exporter\Writer\CsvWriter::class);

--- a/src/Writer/CsvWriter.php
+++ b/src/Writer/CsvWriter.php
@@ -116,7 +116,7 @@ class CsvWriter implements TypedWriterInterface
      */
     public function open()
     {
-        $this->file = fopen($this->filename, 'wb', false);
+        $this->file = fopen($this->filename, 'w', false);
         if ("\n" !== $this->terminate) {
             stream_filter_register('filterTerminate', CsvWriterTerminate::class);
             stream_filter_append($this->file, 'filterTerminate', STREAM_FILTER_WRITE, ['terminate' => $this->terminate]);

--- a/src/Writer/CsvWriterTerminate.php
+++ b/src/Writer/CsvWriterTerminate.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Exporter\Writer;
+namespace Sonata\Exporter\Writer;
 
 /**
  * Filter CSV output to replace the default terminator while supporting active streams.
@@ -37,3 +37,5 @@ final class CsvWriterTerminate extends \php_user_filter
         return PSFS_PASS_ON;
     }
 }
+
+class_exists(\Exporter\Writer\CsvWriterTerminate::class);

--- a/src/Writer/FormattedBoolWriter.php
+++ b/src/Writer/FormattedBoolWriter.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Exporter\Writer;
+namespace Sonata\Exporter\Writer;
 
 /**
  * Format boolean before use another writer.
@@ -74,3 +74,5 @@ class FormattedBoolWriter implements WriterInterface
         $this->writer->write($data);
     }
 }
+
+class_exists(\Exporter\Writer\FormattedBoolWriter::class);

--- a/src/Writer/GsaFeedWriter.php
+++ b/src/Writer/GsaFeedWriter.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Exporter\Writer;
+namespace Sonata\Exporter\Writer;
 
 /**
  * Generates a GSA feed.
@@ -157,3 +157,5 @@ EOF
         fclose($this->buffer);
     }
 }
+
+class_exists(\Exporter\Writer\GsaFeedWriter::class);

--- a/src/Writer/GsaFeedWriter.php
+++ b/src/Writer/GsaFeedWriter.php
@@ -126,7 +126,7 @@ class GsaFeedWriter implements WriterInterface
             throw new \RuntimeException(sprintf('Unable to write to folder: %s', $this->folder));
         }
 
-        $this->buffer = fopen(sprintf('%s/feed_%05d.xml', $this->folder, $this->bufferPart), 'wb');
+        $this->buffer = fopen(sprintf('%s/feed_%05d.xml', $this->folder, $this->bufferPart), 'w');
 
         $this->bufferSize += fwrite($this->buffer, <<<XML
 <?xml version="1.0" encoding="UTF-8"?>

--- a/src/Writer/InMemoryWriter.php
+++ b/src/Writer/InMemoryWriter.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Exporter\Writer;
+namespace Sonata\Exporter\Writer;
 
 class InMemoryWriter implements WriterInterface
 {
@@ -50,3 +50,5 @@ class InMemoryWriter implements WriterInterface
         return $this->elements;
     }
 }
+
+class_exists(\Exporter\Writer\InMemoryWriter::class);

--- a/src/Writer/JsonWriter.php
+++ b/src/Writer/JsonWriter.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Exporter\Writer;
+namespace Sonata\Exporter\Writer;
 
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
@@ -90,3 +90,5 @@ class JsonWriter implements TypedWriterInterface
         ++$this->position;
     }
 }
+
+class_exists(\Exporter\Writer\JsonWriter::class);

--- a/src/Writer/JsonWriter.php
+++ b/src/Writer/JsonWriter.php
@@ -65,7 +65,7 @@ class JsonWriter implements TypedWriterInterface
      */
     public function open()
     {
-        $this->file = fopen($this->filename, 'wb', false);
+        $this->file = fopen($this->filename, 'w', false);
 
         fwrite($this->file, '[');
     }

--- a/src/Writer/SitemapWriter.php
+++ b/src/Writer/SitemapWriter.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Exporter\Writer;
+namespace Sonata\Exporter\Writer;
 
 /**
  * Generates a sitemap site from.
@@ -365,3 +365,5 @@ class SitemapWriter implements WriterInterface
         fclose($this->buffer);
     }
 }
+
+class_exists(\Exporter\Writer\SitemapWriter::class);

--- a/src/Writer/SitemapWriter.php
+++ b/src/Writer/SitemapWriter.php
@@ -199,7 +199,7 @@ class SitemapWriter implements WriterInterface
 
         $filename = sprintf($this->pattern, $this->bufferPart);
 
-        $this->buffer = fopen($this->folder.'/'.$filename, 'wb');
+        $this->buffer = fopen($this->folder.'/'.$filename, 'w');
 
         $this->bufferSize += fwrite($this->buffer, '<?xml version="1.0" encoding="UTF-8"?>'."\n".'<urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd" xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"'.$this->getHeaderByFlag().'>'."\n");
     }

--- a/src/Writer/TypedWriterInterface.php
+++ b/src/Writer/TypedWriterInterface.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Exporter\Writer;
+namespace Sonata\Exporter\Writer;
 
 /**
  * @author Grégoire Paris <postmaster@greg0ire.fr>
@@ -32,3 +32,5 @@ interface TypedWriterInterface extends WriterInterface
      */
     public function getFormat();
 }
+
+interface_exists(\Exporter\Writer\TypedWriterInterface::class);

--- a/src/Writer/WriterInterface.php
+++ b/src/Writer/WriterInterface.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Exporter\Writer;
+namespace Sonata\Exporter\Writer;
 
 interface WriterInterface
 {
@@ -22,3 +22,5 @@ interface WriterInterface
 
     public function close();
 }
+
+interface_exists(\Exporter\Writer\WriterInterfac::class);

--- a/src/Writer/XlsWriter.php
+++ b/src/Writer/XlsWriter.php
@@ -74,7 +74,7 @@ class XlsWriter implements TypedWriterInterface
      */
     public function open()
     {
-        $this->file = fopen($this->filename, 'wb', false);
+        $this->file = fopen($this->filename, 'w', false);
         fwrite($this->file, '<html><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8" /><meta name=ProgId content=Excel.Sheet><meta name=Generator content="https://github.com/sonata-project/exporter"></head><body><table>');
     }
 

--- a/src/Writer/XlsWriter.php
+++ b/src/Writer/XlsWriter.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Exporter\Writer;
+namespace Sonata\Exporter\Writer;
 
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
@@ -122,3 +122,5 @@ class XlsWriter implements TypedWriterInterface
         }
     }
 }
+
+class_exists(\Exporter\Writer\XlsWriter::class);

--- a/src/Writer/XmlExcelWriter.php
+++ b/src/Writer/XmlExcelWriter.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Exporter\Writer;
+namespace Sonata\Exporter\Writer;
 
 /**
  * Generate a Xml Excel file.
@@ -151,3 +151,5 @@ class XmlExcelWriter implements WriterInterface
         return $dataType;
     }
 }
+
+class_exists(\Exporter\Writer\XmlExcelWriter::class);

--- a/src/Writer/XmlExcelWriter.php
+++ b/src/Writer/XmlExcelWriter.php
@@ -70,7 +70,7 @@ class XmlExcelWriter implements WriterInterface
 
     public function open()
     {
-        $this->file = fopen($this->filename, 'wb');
+        $this->file = fopen($this->filename, 'w');
         fwrite($this->file, $this->header);
     }
 

--- a/src/Writer/XmlWriter.php
+++ b/src/Writer/XmlWriter.php
@@ -9,9 +9,9 @@
  * file that was distributed with this source code.
  */
 
-namespace Exporter\Writer;
+namespace Sonata\Exporter\Writer;
 
-use Exporter\Exception\InvalidDataFormatException;
+use Sonata\Exporter\Exception\InvalidDataFormatException;
 
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
@@ -125,3 +125,5 @@ class XmlWriter implements TypedWriterInterface
         }
     }
 }
+
+class_exists(\Exporter\Writer\XmlWriter::class);

--- a/src/Writer/XmlWriter.php
+++ b/src/Writer/XmlWriter.php
@@ -81,7 +81,7 @@ class XmlWriter implements TypedWriterInterface
      */
     public function open()
     {
-        $this->file = fopen($this->filename, 'wb', false);
+        $this->file = fopen($this->filename, 'w', false);
 
         fwrite($this->file, sprintf("<?xml version=\"1.0\" ?>\n<%s>\n", $this->mainElement));
     }

--- a/tests/Bridge/Symfony/DependencyInjection/ConfigurationTest.php
+++ b/tests/Bridge/Symfony/DependencyInjection/ConfigurationTest.php
@@ -11,8 +11,8 @@
 
 namespace Exporter\Tests\Bridge\Symfony\DependencyInjection;
 
-use Exporter\Bridge\Symfony\DependencyInjection\Configuration;
 use Matthias\SymfonyConfigTest\PhpUnit\AbstractConfigurationTestCase;
+use Sonata\Exporter\Bridge\Symfony\DependencyInjection\Configuration;
 
 class ConfigurationTest extends AbstractConfigurationTestCase
 {

--- a/tests/Bridge/Symfony/DependencyInjection/ExporterCompilerPassTest.php
+++ b/tests/Bridge/Symfony/DependencyInjection/ExporterCompilerPassTest.php
@@ -11,8 +11,8 @@
 
 namespace Exporter\Tests\Bridge\Symfony\DependencyInjection\Compiler;
 
-use Exporter\Bridge\Symfony\DependencyInjection\Compiler\ExporterCompilerPass;
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use Sonata\Exporter\Bridge\Symfony\DependencyInjection\Compiler\ExporterCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;

--- a/tests/Bridge/Symfony/DependencyInjection/SonataExporterExtensionTest.php
+++ b/tests/Bridge/Symfony/DependencyInjection/SonataExporterExtensionTest.php
@@ -11,8 +11,8 @@
 
 namespace Exporter\Tests\Bridge\Symfony\DependencyInjection;
 
-use Exporter\Bridge\Symfony\DependencyInjection\SonataExporterExtension;
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
+use Sonata\Exporter\Bridge\Symfony\DependencyInjection\SonataExporterExtension;
 
 class SonataExporterExtensionTest extends AbstractExtensionTestCase
 {

--- a/tests/ExporterTest.php
+++ b/tests/ExporterTest.php
@@ -11,13 +11,13 @@
 
 namespace Exporter\Tests;
 
-use Exporter\Exporter;
-use Exporter\Source\ArraySourceIterator;
-use Exporter\Writer\CsvWriter;
-use Exporter\Writer\JsonWriter;
-use Exporter\Writer\XlsWriter;
-use Exporter\Writer\XmlWriter;
 use PHPUnit\Framework\TestCase;
+use Sonata\Exporter\Exporter;
+use Sonata\Exporter\Source\ArraySourceIterator;
+use Sonata\Exporter\Writer\CsvWriter;
+use Sonata\Exporter\Writer\JsonWriter;
+use Sonata\Exporter\Writer\XlsWriter;
+use Sonata\Exporter\Writer\XmlWriter;
 
 class ExporterTest extends TestCase
 {
@@ -25,8 +25,8 @@ class ExporterTest extends TestCase
     {
         $this->expectException('RuntimeException');
         $this->expectExceptionMessage('Invalid "foo" format');
-        $source = $this->createMock('Exporter\Source\SourceIteratorInterface');
-        $writer = $this->createMock('Exporter\Writer\TypedWriterInterface');
+        $source = $this->createMock('Sonata\Exporter\Source\SourceIteratorInterface');
+        $writer = $this->createMock('Sonata\Exporter\Writer\TypedWriterInterface');
 
         $exporter = new Exporter([$writer]);
         $exporter->getResponse('foo', 'foo', $source);
@@ -45,7 +45,7 @@ class ExporterTest extends TestCase
 
     public function testGetAvailableFormats()
     {
-        $writer = $this->createMock('Exporter\Writer\TypedWriterInterface');
+        $writer = $this->createMock('Sonata\Exporter\Writer\TypedWriterInterface');
         $writer->expects($this->once())
             ->method('getFormat')
             ->willReturn('whatever');
@@ -61,7 +61,7 @@ class ExporterTest extends TestCase
         $source = new ArraySourceIterator([
             ['foo' => 'bar'],
         ]);
-        $writer = $this->createMock('Exporter\Writer\TypedWriterInterface');
+        $writer = $this->createMock('Sonata\Exporter\Writer\TypedWriterInterface');
         $writer->expects($this->any())
             ->method('getFormat')
             ->willReturn('made-up');

--- a/tests/HandlerTest.php
+++ b/tests/HandlerTest.php
@@ -11,8 +11,8 @@
 
 namespace Exporter\Test;
 
-use Exporter\Handler;
 use PHPUnit\Framework\TestCase;
+use Sonata\Exporter\Handler;
 
 class HandlerTest extends TestCase
 {

--- a/tests/Source/ArraySourceIteratorTest.php
+++ b/tests/Source/ArraySourceIteratorTest.php
@@ -11,8 +11,8 @@
 
 namespace Exporter\Test\Source;
 
-use Exporter\Source\ArraySourceIterator;
 use PHPUnit\Framework\TestCase;
+use Sonata\Exporter\Source\ArraySourceIterator;
 
 class ArraySourceIteratorTest extends TestCase
 {

--- a/tests/Source/ChainSourceIteratorTest.php
+++ b/tests/Source/ChainSourceIteratorTest.php
@@ -11,8 +11,8 @@
 
 namespace Exporter\Test\Source;
 
-use Exporter\Source\ChainSourceIterator;
 use PHPUnit\Framework\TestCase;
+use Sonata\Exporter\Source\ChainSourceIterator;
 
 class ChainSourceIteratorTest extends TestCase
 {

--- a/tests/Source/CsvSourceIteratorTest.php
+++ b/tests/Source/CsvSourceIteratorTest.php
@@ -11,8 +11,8 @@
 
 namespace Exporter\Test\Source;
 
-use Exporter\Source\CsvSourceIterator;
 use PHPUnit\Framework\TestCase;
+use Sonata\Exporter\Source\CsvSourceIterator;
 
 class CsvSourceIteratorTest extends TestCase
 {

--- a/tests/Source/Fixtures/DoctrineORMQuerySourceIterator.php
+++ b/tests/Source/Fixtures/DoctrineORMQuerySourceIterator.php
@@ -14,7 +14,7 @@ namespace Exporter\Test\Source\Fixtures;
 /**
  * @author Joseph Maarek <josephmaarek@gmail.com>
  */
-final class DoctrineORMQuerySourceIterator extends \Exporter\Source\DoctrineORMQuerySourceIterator
+final class DoctrineORMQuerySourceIterator extends \Sonata\Exporter\Source\DoctrineORMQuerySourceIterator
 {
     public function getValue($value)
     {

--- a/tests/Source/IteratorCallbackSourceIteratorTest.php
+++ b/tests/Source/IteratorCallbackSourceIteratorTest.php
@@ -11,8 +11,8 @@
 
 namespace Exporter\Test\Source;
 
-use Exporter\Source\IteratorCallbackSourceIterator;
 use PHPUnit\Framework\TestCase;
+use Sonata\Exporter\Source\IteratorCallbackSourceIterator;
 
 class IteratorCallbackSourceIteratorTest extends TestCase
 {

--- a/tests/Source/IteratorSourceIteratorTest.php
+++ b/tests/Source/IteratorSourceIteratorTest.php
@@ -11,8 +11,8 @@
 
 namespace Exporter\Test\Source;
 
-use Exporter\Source\IteratorSourceIterator;
 use PHPUnit\Framework\TestCase;
+use Sonata\Exporter\Source\IteratorSourceIterator;
 
 class IteratorSourceIteratorTest extends TestCase
 {

--- a/tests/Source/PDOStatementSourceIteratorTest.php
+++ b/tests/Source/PDOStatementSourceIteratorTest.php
@@ -11,8 +11,8 @@
 
 namespace Exporter\Test\Source;
 
-use Exporter\Source\PDOStatementSourceIterator;
 use PHPUnit\Framework\TestCase;
+use Sonata\Exporter\Source\PDOStatementSourceIterator;
 
 class PDOStatementSourceIteratorTest extends TestCase
 {

--- a/tests/Source/PropelCollectionSourceIteratorTest.php
+++ b/tests/Source/PropelCollectionSourceIteratorTest.php
@@ -11,8 +11,8 @@
 
 namespace Exporter\Test\Source;
 
-use Exporter\Source\PropelCollectionSourceIterator;
 use PHPUnit\Framework\TestCase;
+use Sonata\Exporter\Source\PropelCollectionSourceIterator;
 
 /**
  * Tests the PropelCollectionSourceIterator class.

--- a/tests/Source/XmlExcelSourceIteratorTest.php
+++ b/tests/Source/XmlExcelSourceIteratorTest.php
@@ -11,8 +11,8 @@
 
 namespace Exporter\Test\Source;
 
-use Exporter\Source\XmlExcelSourceIterator;
 use PHPUnit\Framework\TestCase;
+use Sonata\Exporter\Source\XmlExcelSourceIterator;
 
 class XmlExcelSourceIteratorTest extends TestCase
 {

--- a/tests/Source/XmlSourceIteratorTest.php
+++ b/tests/Source/XmlSourceIteratorTest.php
@@ -11,8 +11,8 @@
 
 namespace Exporter\Test\Source;
 
-use Exporter\Source\XmlSourceIterator;
 use PHPUnit\Framework\TestCase;
+use Sonata\Exporter\Source\XmlSourceIterator;
 
 class XmlSourceIteratorTest extends TestCase
 {

--- a/tests/Writer/AbstractTypedWriterTestCase.php
+++ b/tests/Writer/AbstractTypedWriterTestCase.php
@@ -11,7 +11,7 @@
 
 namespace Exporter\Test\Writer;
 
-use Exporter\Test\AbstractTypedWriterTestCase as BaseTestCase;
+use Sonata\Exporter\Test\AbstractTypedWriterTestCase as BaseTestCase;
 
 @trigger_error(
     'The '.__NAMESPACE__.'\AbstractTypedWriterTestCase class is deprecated since version 1.6 and will be removed in 2.0.'

--- a/tests/Writer/CsvWriterTerminateTest.php
+++ b/tests/Writer/CsvWriterTerminateTest.php
@@ -38,7 +38,7 @@ class CsvWriterTerminateTest extends AbstractTypedWriterTestCase
 
     public function testFilter()
     {
-        $file = fopen($this->filename, 'wb', false);
+        $file = fopen($this->filename, 'w', false);
         stream_filter_register('filter', CsvWriterTerminate::class);
         stream_filter_append($file, 'filter', STREAM_FILTER_WRITE, ['terminate' => "\r\n"]);
         @fputcsv($file, ['john', 'doe', '1']);

--- a/tests/Writer/CsvWriterTerminateTest.php
+++ b/tests/Writer/CsvWriterTerminateTest.php
@@ -11,9 +11,9 @@
 
 namespace Exporter\Test\Writer;
 
-use Exporter\Test\AbstractTypedWriterTestCase;
-use Exporter\Writer\CsvWriter;
-use Exporter\Writer\CsvWriterTerminate;
+use Sonata\Exporter\Test\AbstractTypedWriterTestCase;
+use Sonata\Exporter\Writer\CsvWriter;
+use Sonata\Exporter\Writer\CsvWriterTerminate;
 
 class CsvWriterTerminateTest extends AbstractTypedWriterTestCase
 {

--- a/tests/Writer/CsvWriterTest.php
+++ b/tests/Writer/CsvWriterTest.php
@@ -11,8 +11,8 @@
 
 namespace Exporter\Test\Writer;
 
-use Exporter\Test\AbstractTypedWriterTestCase;
-use Exporter\Writer\CsvWriter;
+use Sonata\Exporter\Test\AbstractTypedWriterTestCase;
+use Sonata\Exporter\Writer\CsvWriter;
 
 class CsvWriterTest extends AbstractTypedWriterTestCase
 {

--- a/tests/Writer/FormattedBoolWriterTest.php
+++ b/tests/Writer/FormattedBoolWriterTest.php
@@ -11,8 +11,8 @@
 
 namespace Exporter\Test\Writer;
 
-use Exporter\Writer\FormattedBoolWriter;
 use PHPUnit\Framework\TestCase;
+use Sonata\Exporter\Writer\FormattedBoolWriter;
 
 /**
  * Format boolean before use another writer.

--- a/tests/Writer/GsaFeedWriterTest.php
+++ b/tests/Writer/GsaFeedWriterTest.php
@@ -11,8 +11,8 @@
 
 namespace Exporter\Test\Writer;
 
-use Exporter\Writer\GsaFeedWriter;
 use PHPUnit\Framework\TestCase;
+use Sonata\Exporter\Writer\GsaFeedWriter;
 
 /**
  * Tests the GSA feed writer class.

--- a/tests/Writer/JsonWriterTest.php
+++ b/tests/Writer/JsonWriterTest.php
@@ -11,8 +11,8 @@
 
 namespace Exporter\Test\Writer;
 
-use Exporter\Test\AbstractTypedWriterTestCase;
-use Exporter\Writer\JsonWriter;
+use Sonata\Exporter\Test\AbstractTypedWriterTestCase;
+use Sonata\Exporter\Writer\JsonWriter;
 
 class JsonWriterTest extends AbstractTypedWriterTestCase
 {

--- a/tests/Writer/SitemapWriterTest.php
+++ b/tests/Writer/SitemapWriterTest.php
@@ -11,9 +11,9 @@
 
 namespace Exporter\Test\Writer;
 
-use Exporter\Writer\SitemapWriter;
 use PHPUnit\Framework\TestCase;
 use SimpleXMLElement;
+use Sonata\Exporter\Writer\SitemapWriter;
 
 class SitemapWriterTest extends TestCase
 {

--- a/tests/Writer/XlsWriterTest.php
+++ b/tests/Writer/XlsWriterTest.php
@@ -11,8 +11,8 @@
 
 namespace Exporter\Test\Writer;
 
-use Exporter\Test\AbstractTypedWriterTestCase;
-use Exporter\Writer\XlsWriter;
+use Sonata\Exporter\Test\AbstractTypedWriterTestCase;
+use Sonata\Exporter\Writer\XlsWriter;
 
 class XlsWriterTest extends AbstractTypedWriterTestCase
 {

--- a/tests/Writer/XmlExcelWriterTest.php
+++ b/tests/Writer/XmlExcelWriterTest.php
@@ -11,8 +11,8 @@
 
 namespace Exporter\Test\Writer;
 
-use Exporter\Writer\XmlExcelWriter;
 use PHPUnit\Framework\TestCase;
+use Sonata\Exporter\Writer\XmlExcelWriter;
 
 class XmlExcelWriterTest extends TestCase
 {

--- a/tests/Writer/XmlWriterTest.php
+++ b/tests/Writer/XmlWriterTest.php
@@ -11,8 +11,8 @@
 
 namespace Exporter\Test\Writer;
 
-use Exporter\Test\AbstractTypedWriterTestCase;
-use Exporter\Writer\XmlWriter;
+use Sonata\Exporter\Test\AbstractTypedWriterTestCase;
+use Sonata\Exporter\Writer\XmlWriter;
 
 class XmlWriterTest extends AbstractTypedWriterTestCase
 {


### PR DESCRIPTION
## Subject
This makes it possible to use the new namespaces in 1.x, which should make migration way easier for everyone

I am targeting this branch, because this is BC.


Fixes #198


## Changelog


<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Forward-compatibility layer with `Sonata`-prefixed namespaces
```

## How can I test this on my project?

```
composer config repositories.greg0ire vcs https://github.com/greg0ire/exporter
composer require sonata-project/exporter "dev-compat_layer as 1.42.0"
```
