### PR TITLE
Fixed wrong namespace

### DIFF
--- a/src/Bridge/Symfony/Bundle/SonataExporterBundle.php
+++ b/src/Bridge/Symfony/Bundle/SonataExporterBundle.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace Sonata\Exporter\Bridge\Symfony\Bundle;
 
-use Exporter\Bridge\Symfony\DependencyInjection\SonataExporterExtension;
 use Sonata\Exporter\Bridge\Symfony\DependencyInjection\Compiler\ExporterCompilerPass;
+use Sonata\Exporter\Bridge\Symfony\DependencyInjection\SonataExporterExtension;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 

--- a/src/Bridge/Symfony/Resources/config/services.xml
+++ b/src/Bridge/Symfony/Resources/config/services.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
-        <service id="sonata.exporter.writer.csv" class="Exporter\Writer\CsvWriter" public="false">
+        <service id="sonata.exporter.writer.csv" class="Sonata\Exporter\Writer\CsvWriter" public="false">
             <argument>%sonata.exporter.writer.csv.filename%</argument>
             <argument>%sonata.exporter.writer.csv.delimiter%</argument>
             <argument>%sonata.exporter.writer.csv.enclosure%</argument>
@@ -9,19 +9,19 @@
             <argument>%sonata.exporter.writer.csv.show_headers%</argument>
             <argument>%sonata.exporter.writer.csv.with_bom%</argument>
         </service>
-        <service id="sonata.exporter.writer.json" class="Exporter\Writer\JsonWriter" public="false">
+        <service id="sonata.exporter.writer.json" class="Sonata\Exporter\Writer\JsonWriter" public="false">
             <argument>%sonata.exporter.writer.json.filename%</argument>
         </service>
-        <service id="sonata.exporter.writer.xls" class="Exporter\Writer\XlsWriter" public="false">
+        <service id="sonata.exporter.writer.xls" class="Sonata\Exporter\Writer\XlsWriter" public="false">
             <argument>%sonata.exporter.writer.xls.filename%</argument>
             <argument>%sonata.exporter.writer.xls.show_headers%</argument>
         </service>
-        <service id="sonata.exporter.writer.xml" class="Exporter\Writer\XmlWriter" public="false">
+        <service id="sonata.exporter.writer.xml" class="Sonata\Exporter\Writer\XmlWriter" public="false">
             <argument>%sonata.exporter.writer.xml.filename%</argument>
             <argument>%sonata.exporter.writer.xml.main_element%</argument>
             <argument>%sonata.exporter.writer.xml.child_element%</argument>
         </service>
-        <service id="sonata.exporter.exporter" class="Exporter\Exporter" public="true"/>
-        <service id="Exporter\Exporter" alias="sonata.exporter.exporter"/>
+        <service id="sonata.exporter.exporter" class="Sonata\Exporter\Exporter" public="true"/>
+        <service id="Sonata\Exporter\Exporter" alias="sonata.exporter.exporter"/>
     </services>
 </container>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
The `Exporter\*` namespace does not exist.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/exporter/blob/2.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a bugfix.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/exporter/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed wrong namespace usage
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
