### PR TITLE
remove final class

### DIFF
--- a/src/Exporter.php
+++ b/src/Exporter.php
@@ -20,7 +20,7 @@ use Symfony\Component\HttpFoundation\StreamedResponse;
 /**
  * @author Grégoire Paris <postmaster@greg0ire.fr>
  */
-final class Exporter
+class Exporter
 {
     /**
      * @var TypedWriterInterface[]

--- a/src/Handler.php
+++ b/src/Handler.php
@@ -16,7 +16,7 @@ namespace Sonata\Exporter;
 use Sonata\Exporter\Source\SourceIteratorInterface;
 use Sonata\Exporter\Writer\WriterInterface;
 
-final class Handler
+class Handler
 {
     /**
      * @var SourceIteratorInterface


### PR DESCRIPTION
## Allowing extends _Handler_ and _Exporter_ classes

Removing **final** keyword on _Handler_ and _Exporter_ classes

I am targeting this branch, because it's backward compatible.

## Motivation

I know it goes against the meaning of changelog 2.x

In my case, i want to give more data to a customized writer (want to give a docx template, datas, schema and files).
I need to call a newly created **getWriter(string $format)** method on **Exporter**. 

```php
public function getWriter(string $format)
{
    if(isset($this->writers[$format]) && $this->writers[$format] !== null){
        return $this->writers[$format];
    }

    return false;
}
```
Without extending, i have to rewrite the whole **Exporter** class. 
And Decorator pattern doesn't works in this case... (cant access to **private $writers;** from an **ExporterDecorator** class)

This newly created method is used from a service that i create (in symfony), where **Exporter** is instantiated in _$this->exporter_ :

```php
$writer = $this->exporter->getWriter($format);
$writer
    ->setTemplatePath($template)
    ->setSchema($schema)
    ->setFiles($files)
;
```

My writer is a DocxWriter that i created.

I think i've a similar case of https://github.com/sonata-project/exporter/issues/286

## Changelog

Minimal modifications, no changelog.

## To do
    
- [x] Update the tests
- [x] Update the documentation
- [ ] Add an upgrade note
