### PR TITLE
Upgrade to phpunit 8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .php_cs.cache
 composer.lock
 phpunit.xml
+/.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ env:
     - SYMFONY_DEPRECATIONS_HELPER=weak_vendors
     - TARGET=test
     - UPSTREAM_URL=https://github.com/sonata-project/exporter.git
-    - PHPUNIT_VERSION=7
+    - PHPUNIT_VERSION=8
 
 matrix:
   fast_finish: true

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "doctrine/dbal": "^2.5",
         "doctrine/orm": "^2.4.5",
         "matthiasnoback/symfony-config-test": "^4.0",
-        "matthiasnoback/symfony-dependency-injection-test": "^3.0",
+        "matthiasnoback/symfony-dependency-injection-test": "^4.0",
         "propel/propel1": "^1.6",
         "symfony/config": "^3.4 || ^4.0",
         "symfony/dependency-injection": "^3.4 || ^4.0",

--- a/src/Test/AbstractTypedWriterTestCase.php
+++ b/src/Test/AbstractTypedWriterTestCase.php
@@ -33,12 +33,12 @@ abstract class AbstractTypedWriterTestCase extends TestCase
 
     final public function testFormatIsString(): void
     {
-        $this->assertInternalType('string', $this->writer->getFormat());
+        $this->assertIsString($this->writer->getFormat());
     }
 
     final public function testDefaultMimeTypeIsString(): void
     {
-        $this->assertInternalType('string', $this->writer->getDefaultMimeType());
+        $this->assertIsString($this->writer->getDefaultMimeType());
     }
 
     abstract protected function getWriter(): TypedWriterInterface;

--- a/tests/Bridge/Symfony/DependencyInjection/SonataExporterExtensionTest.php
+++ b/tests/Bridge/Symfony/DependencyInjection/SonataExporterExtensionTest.php
@@ -45,7 +45,7 @@ class SonataExporterExtensionTest extends AbstractExtensionTestCase
         }
     }
 
-    protected function getContainerExtensions()
+    protected function getContainerExtensions(): array
     {
         return [
             new SonataExporterExtension(),

--- a/tests/Source/ArraySourceIteratorTest.php
+++ b/tests/Source/ArraySourceIteratorTest.php
@@ -30,7 +30,7 @@ class ArraySourceIteratorTest extends TestCase
         $iterator = new ArraySourceIterator($data);
 
         foreach ($iterator as $value) {
-            $this->assertInternalType('array', $value);
+            $this->assertIsArray($value);
             $this->assertCount(3, $value);
         }
     }

--- a/tests/Source/CsvSourceIteratorTest.php
+++ b/tests/Source/CsvSourceIteratorTest.php
@@ -48,7 +48,7 @@ EOF;
 
         $i = 0;
         foreach ($iterator as $value) {
-            $this->assertInternalType('array', $value);
+            $this->assertIsArray($value);
             $this->assertCount(2, $value);
             $this->assertSame($i, $iterator->key());
             $keys = array_keys($value);
@@ -65,7 +65,7 @@ EOF;
 
         $i = 0;
         foreach ($iterator as $value) {
-            $this->assertInternalType('array', $value);
+            $this->assertIsArray($value);
             $this->assertCount(2, $value);
             $this->assertSame($i, $iterator->key());
             ++$i;
@@ -79,7 +79,7 @@ EOF;
 
         $i = 0;
         foreach ($iterator as $value) {
-            $this->assertInternalType('array', $value);
+            $this->assertIsArray($value);
             $this->assertCount(2, $value);
             ++$i;
         }
@@ -87,7 +87,7 @@ EOF;
 
         $i = 0;
         foreach ($iterator as $value) {
-            $this->assertInternalType('array', $value);
+            $this->assertIsArray($value);
             $this->assertCount(2, $value);
             ++$i;
         }

--- a/tests/Source/IteratorSourceIteratorTest.php
+++ b/tests/Source/IteratorSourceIteratorTest.php
@@ -43,7 +43,7 @@ class IteratorSourceIteratorTest extends TestCase
         $this->iterator
             ->expects(self::once())
             ->method('current')
-            ->will($this->returnValue(['current']));
+            ->willReturn(['current']);
 
         self::assertSame(['current'], $this->sourceIterator->current());
     }
@@ -62,7 +62,7 @@ class IteratorSourceIteratorTest extends TestCase
         $this->iterator
             ->expects(self::once())
             ->method('key')
-            ->will($this->returnValue('key'));
+            ->willReturn('key');
 
         self::assertSame('key', $this->sourceIterator->key());
     }
@@ -72,7 +72,7 @@ class IteratorSourceIteratorTest extends TestCase
         $this->iterator
             ->expects(self::once())
             ->method('valid')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         self::assertTrue($this->sourceIterator->valid());
     }

--- a/tests/Source/PropelCollectionSourceIteratorTest.php
+++ b/tests/Source/PropelCollectionSourceIteratorTest.php
@@ -74,7 +74,7 @@ class PropelCollectionSourceIteratorTest extends TestCase
 
         foreach ($data as $row) {
             $this->assertArrayHasKey('created_at', $row);
-            $this->assertInternalType('string', $row['created_at']);
+            $this->assertIsString($row['created_at']);
         }
     }
 

--- a/tests/Source/XmlExcelSourceIteratorTest.php
+++ b/tests/Source/XmlExcelSourceIteratorTest.php
@@ -51,7 +51,7 @@ class XmlExcelSourceIteratorTest extends TestCase
 
         $i = 0;
         foreach ($iterator as $value) {
-            $this->assertInternalType('array', $value);
+            $this->assertIsArray($value);
             $this->assertCount(3, $value);
             $keys = array_keys($value);
             $this->assertSame($i, $iterator->key());
@@ -69,7 +69,7 @@ class XmlExcelSourceIteratorTest extends TestCase
 
         $i = 0;
         foreach ($iterator as $value) {
-            $this->assertInternalType('array', $value);
+            $this->assertIsArray($value);
             $this->assertCount(3, $value);
             $keys = array_keys($value);
             $this->assertSame($i, $iterator->key());
@@ -87,7 +87,7 @@ class XmlExcelSourceIteratorTest extends TestCase
 
         $i = 0;
         foreach ($iterator as $value) {
-            $this->assertInternalType('array', $value);
+            $this->assertIsArray($value);
             $this->assertCount(3, $value);
             $this->assertSame($i, $iterator->key());
             ++$i;
@@ -101,7 +101,7 @@ class XmlExcelSourceIteratorTest extends TestCase
 
         $i = 0;
         foreach ($iterator as $value) {
-            $this->assertInternalType('array', $value);
+            $this->assertIsArray($value);
             $this->assertCount(3, $value);
             ++$i;
         }
@@ -109,7 +109,7 @@ class XmlExcelSourceIteratorTest extends TestCase
 
         $i = 0;
         foreach ($iterator as $value) {
-            $this->assertInternalType('array', $value);
+            $this->assertIsArray($value);
             $this->assertCount(3, $value);
             ++$i;
         }

--- a/tests/Source/XmlSourceIteratorTest.php
+++ b/tests/Source/XmlSourceIteratorTest.php
@@ -45,7 +45,7 @@ class XmlSourceIteratorTest extends TestCase
 
         $i = 0;
         foreach ($iterator as $value) {
-            $this->assertInternalType('array', $value);
+            $this->assertIsArray($value);
             $this->assertCount(3, $value);
             $keys = array_keys($value);
             $this->assertSame($i, $iterator->key());
@@ -63,7 +63,7 @@ class XmlSourceIteratorTest extends TestCase
 
         $i = 0;
         foreach ($iterator as $value) {
-            $this->assertInternalType('array', $value);
+            $this->assertIsArray($value);
             $this->assertCount(3, $value);
             ++$i;
         }
@@ -71,7 +71,7 @@ class XmlSourceIteratorTest extends TestCase
 
         $i = 0;
         foreach ($iterator as $value) {
-            $this->assertInternalType('array', $value);
+            $this->assertIsArray($value);
             $this->assertCount(3, $value);
             ++$i;
         }
@@ -84,7 +84,7 @@ class XmlSourceIteratorTest extends TestCase
 
         $i = 0;
         foreach ($iterator as $value) {
-            $this->assertInternalType('array', $value);
+            $this->assertIsArray($value);
             $this->assertCount(3, $value);
             $keys = array_keys($value);
             $this->assertSame($i, $iterator->key());


### PR DESCRIPTION
Makes `composer outdated` empty. Requires a dev-kit PR, but let's see how things go tonight first :)