### PR TITLE
Fix realpath on tests

### DIFF
--- a/tests/Writer/GsaFeedWriterTest.php
+++ b/tests/Writer/GsaFeedWriterTest.php
@@ -104,7 +104,7 @@ class GsaFeedWriterTest extends TestCase
         $generatedFiles = $this->getFiles();
 
         $this->assertCount(1, $generatedFiles);
-        $this->assertSame($this->folder.'/feed_00001.xml', $generatedFiles[0]);
+        $this->assertSame($this->folder->getRealPath().'/feed_00001.xml', $generatedFiles[0]);
 
         // this will throw an exception if the xml is invalid
         new \SimpleXMLElement(file_get_contents($generatedFiles[0]), LIBXML_PARSEHUGE);


### PR DESCRIPTION
I'm using Mac OS and I get this error on tests:
```
1) Sonata\Exporter\Tests\Writer\GsaFeedWriterTest::testSimpleWrite
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'/var/folders/48/fkmnn6gs2998gq8wc5f83d780000gn/T/sonata_exporter_test/feed_00001.xml'
+'/private/var/folders/48/fkmnn6gs2998gq8wc5f83d780000gn/T/sonata_exporter_test/feed_00001.xml'
```
