### PR TITLE
Add throw annotation

### DIFF
--- a/src/Exception/InvalidDataFormatException.php
+++ b/src/Exception/InvalidDataFormatException.php
@@ -13,6 +13,6 @@ declare(strict_types=1);
 
 namespace Sonata\Exporter\Exception;
 
-final class InvalidDataFormatException extends \RuntimeException implements SonataExporterException
+final class InvalidDataFormatException extends RuntimeException implements SonataExporterException
 {
 }

--- a/src/Exception/RuntimeException.php
+++ b/src/Exception/RuntimeException.php
@@ -13,6 +13,6 @@ declare(strict_types=1);
 
 namespace Sonata\Exporter\Exception;
 
-final class InvalidMethodCallException extends RuntimeException implements SonataExporterException
+class RuntimeException extends \RuntimeException implements SonataExporterException
 {
 }

--- a/src/Writer/CsvWriter.php
+++ b/src/Writer/CsvWriter.php
@@ -65,6 +65,9 @@ final class CsvWriter implements TypedWriterInterface
      */
     private $terminate;
 
+    /**
+     * @throws \RuntimeException
+     */
     public function __construct(
         string $filename,
         string $delimiter = ',',
@@ -115,6 +118,9 @@ final class CsvWriter implements TypedWriterInterface
         fclose($this->file);
     }
 
+    /**
+     * @throws InvalidDataFormatException
+     */
     public function write(array $data): void
     {
         if (0 === $this->position && $this->showHeaders) {

--- a/src/Writer/CsvWriter.php
+++ b/src/Writer/CsvWriter.php
@@ -118,9 +118,6 @@ final class CsvWriter implements TypedWriterInterface
         fclose($this->file);
     }
 
-    /**
-     * @throws InvalidDataFormatException
-     */
     public function write(array $data): void
     {
         if (0 === $this->position && $this->showHeaders) {

--- a/src/Writer/GsaFeedWriter.php
+++ b/src/Writer/GsaFeedWriter.php
@@ -73,11 +73,17 @@ final class GsaFeedWriter implements WriterInterface
         $this->bufferSize = 0;
     }
 
+    /**
+     * @throws \RuntimeException
+     */
     public function open(): void
     {
         $this->generateNewPart();
     }
 
+    /**
+     * @throws \RuntimeException
+     */
     public function write(array $data): void
     {
         $line = sprintf("        <record url=\"%s\" mimetype=\"%s\" action=\"%s\"/>\n",

--- a/src/Writer/GsaFeedWriter.php
+++ b/src/Writer/GsaFeedWriter.php
@@ -73,17 +73,11 @@ final class GsaFeedWriter implements WriterInterface
         $this->bufferSize = 0;
     }
 
-    /**
-     * @throws \RuntimeException
-     */
     public function open(): void
     {
         $this->generateNewPart();
     }
 
-    /**
-     * @throws \RuntimeException
-     */
     public function write(array $data): void
     {
         $line = sprintf("        <record url=\"%s\" mimetype=\"%s\" action=\"%s\"/>\n",

--- a/src/Writer/JsonWriter.php
+++ b/src/Writer/JsonWriter.php
@@ -33,6 +33,9 @@ final class JsonWriter implements TypedWriterInterface
      */
     private $position = 0;
 
+    /**
+     * @throws \RuntimeException
+     */
     public function __construct(string $filename)
     {
         $this->filename = $filename;

--- a/src/Writer/SitemapWriter.php
+++ b/src/Writer/SitemapWriter.php
@@ -98,18 +98,12 @@ final class SitemapWriter implements WriterInterface
         return $this->folder;
     }
 
-    /**
-     * @throws \RuntimeException
-     */
     public function open(): void
     {
         $this->bufferPart = 0;
         $this->generateNewPart();
     }
 
-    /**
-     * @throws \RuntimeException
-     */
     public function write(array $data): void
     {
         $data = $this->buildData($data);

--- a/src/Writer/SitemapWriter.php
+++ b/src/Writer/SitemapWriter.php
@@ -98,12 +98,18 @@ final class SitemapWriter implements WriterInterface
         return $this->folder;
     }
 
+    /**
+     * @throws \RuntimeException
+     */
     public function open(): void
     {
         $this->bufferPart = 0;
         $this->generateNewPart();
     }
 
+    /**
+     * @throws \RuntimeException
+     */
     public function write(array $data): void
     {
         $data = $this->buildData($data);

--- a/src/Writer/WriterInterface.php
+++ b/src/Writer/WriterInterface.php
@@ -13,15 +13,17 @@ declare(strict_types=1);
 
 namespace Sonata\Exporter\Writer;
 
+use Sonata\Exporter\Exception\SonataExporterException;
+
 interface WriterInterface
 {
     /**
-     * @throws \RuntimeException
+     * @throws SonataExporterException
      */
     public function open();
 
     /**
-     * @throws \RuntimeException
+     * @throws SonataExporterException
      */
     public function write(array $data);
 

--- a/src/Writer/WriterInterface.php
+++ b/src/Writer/WriterInterface.php
@@ -15,8 +15,14 @@ namespace Sonata\Exporter\Writer;
 
 interface WriterInterface
 {
+    /**
+     * @throws \RuntimeException
+     */
     public function open();
 
+    /**
+     * @throws \RuntimeException
+     */
     public function write(array $data);
 
     public function close();

--- a/src/Writer/XmlExcelWriter.php
+++ b/src/Writer/XmlExcelWriter.php
@@ -56,6 +56,8 @@ final class XmlExcelWriter implements WriterInterface
      *                           If string: force all cells to the given type. e.g: 'Number'
      *                           If array: force only given cells. e.g: array('ean'=>'String', 'price'=>'Number')
      *                           If null: will guess the type. 'Number' if value is numeric, 'String' otherwise
+     *
+     * @throws \RuntimeException
      */
     public function __construct(string $filename, bool $showHeaders = true, $columnsType = null)
     {

--- a/src/Writer/XmlWriter.php
+++ b/src/Writer/XmlWriter.php
@@ -45,6 +45,9 @@ final class XmlWriter implements TypedWriterInterface
      */
     private $childElement;
 
+    /**
+     * @throws \RuntimeException
+     */
     public function __construct(string $filename, string $mainElement = 'datas', string $childElement = 'data')
     {
         $this->filename = $filename;
@@ -80,6 +83,9 @@ final class XmlWriter implements TypedWriterInterface
         fclose($this->file);
     }
 
+    /**
+     * @throws \RuntimeException
+     */
     public function write(array $data): void
     {
         fwrite($this->file, sprintf("<%s>\n", $this->childElement));
@@ -93,6 +99,8 @@ final class XmlWriter implements TypedWriterInterface
 
     /**
      * @param mixed $value
+     *
+     * @throws \RuntimeException
      */
     private function generateNode(string $name, $value): void
     {

--- a/src/Writer/XmlWriter.php
+++ b/src/Writer/XmlWriter.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sonata\Exporter\Writer;
 
 use Sonata\Exporter\Exception\InvalidDataFormatException;
+use Sonata\Exporter\Exception\RuntimeException;
 
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
@@ -83,9 +84,6 @@ final class XmlWriter implements TypedWriterInterface
         fclose($this->file);
     }
 
-    /**
-     * @throws \RuntimeException
-     */
     public function write(array $data): void
     {
         fwrite($this->file, sprintf("<%s>\n", $this->childElement));
@@ -105,7 +103,7 @@ final class XmlWriter implements TypedWriterInterface
     private function generateNode(string $name, $value): void
     {
         if (\is_array($value)) {
-            throw new \RuntimeException('Not implemented');
+            throw new RuntimeException('Not implemented');
         } elseif (is_scalar($value) || null === $value) {
             fwrite($this->file, sprintf("<%s><![CDATA[%s]]></%s>\n", $name, $value, $name));
         } else {


### PR DESCRIPTION
## Subject

I am targeting this branch, because it's just phpdoc.

`open` and `write` function can throws \RuntimeException. Let's warn about this.
When using a tool checking for try/catch, a wrong phpdoc give a weird behaviour.

## Changelog

Not needed for phpdoc