### PR TITLE
Change default date format to ISO standard

### DIFF
--- a/src/Source/DoctrineODMQuerySourceIterator.php
+++ b/src/Source/DoctrineODMQuerySourceIterator.php
@@ -50,7 +50,7 @@ final class DoctrineODMQuerySourceIterator implements SourceIteratorInterface
      * @param Query $query  The Doctrine Query
      * @param array $fields Fields to export
      */
-    public function __construct(Query $query, array $fields, string $dateTimeFormat = 'r')
+    public function __construct(Query $query, array $fields, string $dateTimeFormat = \DateTimeInterface::ATOM)
     {
         $this->query = clone $query;
 

--- a/tests/Source/DoctrineODMQuerySourceIteratorTest.php
+++ b/tests/Source/DoctrineODMQuerySourceIteratorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\Exporter\Tests\Source;
+
+use DateTimeInterface;
+use Doctrine\ODM\MongoDB\Query\Query;
+use PHPUnit\Framework\TestCase;
+use Sonata\Exporter\Source\DoctrineODMQuerySourceIterator;
+
+class DoctrineODMQuerySourceIteratorTest extends TestCase
+{
+    public function testGetDateTimeFormat(): void
+    {
+        $query = $this->createStub(Query::class);
+
+        $iterator = new DoctrineODMQuerySourceIterator($query, []);
+
+        self::assertSame(DateTimeInterface::ATOM, $iterator->getDateTimeFormat());
+    }
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

The ISO 8601 format is more common for dates.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/exporter/blob/2.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a BC break.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/exporter/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Change default date format to ISO standard
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
