### PR TITLE
Add `SonataExporterSymfonyBundle` in order to be compatible with Symfony Flex

### DIFF
--- a/UPGRADE-2.x.md
+++ b/UPGRADE-2.x.md
@@ -1,1 +1,6 @@
 # UPGRADE 2.x
+
+### `Sonata\Exporter\Bridge\Symfony\Bundle\SonataExporterBundle`
+
+Deprecated `Sonata\Exporter\Bridge\Symfony\Bundle\SonataExporterBundle`. Use `Sonata\Exporter\Bridge\Symfony\SonataExporterBundle`
+instead.

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,8 @@
     },
     "autoload": {
         "psr-4": {
-            "Sonata\\Exporter\\": "src/"
+            "Sonata\\Exporter\\": "src/",
+            "Sonata\\Exporter\\Bridge\\Symfony\\": "src/Bridge/Symfony/"
         }
     },
     "autoload-dev": {

--- a/docs/reference/symfony.rst
+++ b/docs/reference/symfony.rst
@@ -16,7 +16,7 @@ Now, enable the bundle in ``bundles.php`` file::
 
     return [
         // ...
-        Sonata\Exporter\Bridge\Symfony\Bundle\SonataExporterBundle::class => ['all' => true],
+        Sonata\Exporter\Bridge\Symfony\SonataExporterBundle::class => ['all' => true],
     ];
 
 The default writers

--- a/src/Bridge/Symfony/Bundle/SonataExporterBundle.php
+++ b/src/Bridge/Symfony/Bundle/SonataExporterBundle.php
@@ -13,20 +13,24 @@ declare(strict_types=1);
 
 namespace Sonata\Exporter\Bridge\Symfony\Bundle;
 
-use Sonata\Exporter\Bridge\Symfony\DependencyInjection\Compiler\ExporterCompilerPass;
-use Sonata\Exporter\Bridge\Symfony\DependencyInjection\SonataExporterExtension;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Sonata\Exporter\Bridge\Symfony\SonataExporterBundle;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
-final class SonataExporterBundle extends Bundle
-{
-    public function build(ContainerBuilder $container): void
-    {
-        $container->addCompilerPass(new ExporterCompilerPass());
-    }
+@trigger_error(sprintf(
+    'The %s\SonataExporterBundle class is deprecated since sonata-project/exporter 2.x, to be removed in version 3.0. Use %s instead.',
+    __NAMESPACE__,
+    SonataExporterBundle::class
+), E_USER_DEPRECATED);
 
-    protected function getContainerExtensionClass(): string
+if (false) {
+    /**
+     * NEXT_MAJOR: remove this class.
+     *
+     * @deprecated since sonata-project/exporter 2.x, to be removed in version 3.0. Use Sonata\Exporter\Bridge\Symfony\SonataExporterBundle instead.
+     */
+    final class SonataExporterBundle extends Bundle
     {
-        return SonataExporterExtension::class;
     }
 }
+
+class_alias(SonataExporterBundle::class, __NAMESPACE__.'\SonataExporterBundle');

--- a/src/Bridge/Symfony/SonataExporterBundle.php
+++ b/src/Bridge/Symfony/SonataExporterBundle.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\Exporter\Bridge\Symfony;
+
+use Sonata\Exporter\Bridge\Symfony\DependencyInjection\Compiler\ExporterCompilerPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+final class SonataExporterBundle extends Bundle
+{
+    public function build(ContainerBuilder $container): void
+    {
+        $container->addCompilerPass(new ExporterCompilerPass());
+    }
+}

--- a/src/Bridge/Symfony/SonataExporterSymfonyBundle.php
+++ b/src/Bridge/Symfony/SonataExporterSymfonyBundle.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\Exporter\Bridge\Symfony;
+
+// This file and its class alias is required in order to let Symfony Flex
+// autodiscovery to find the bundle.
+// The string "Symfony\Component\HttpKernel\Bundle\Bundle" must also be present.
+// @see https://github.com/symfony/flex/pull/612/files.
+class_alias(SonataExporterBundle::class, __NAMESPACE__.'\SonataExporterSymfonyBundle');


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Add `SonataExporterSymfonyBundle` in order to be compatible with Symfony Flex.
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/exporter/blob/2.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because these changes respect BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/exporter/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added `Sonata\Exporter\Bridge\Symfony\SonataExporterBundle`.
- Added `Sonata\Exporter\Bridge\Symfony\SonataExporterSymfonyBundle` alias in order to fix Symfony Flex autodiscovery.

### Deprecated
- Deprecated `Sonata\Exporter\Bridge\Symfony\Bundle\SonataExporterBundle` in favor of `Sonata\Exporter\Bridge\Symfony\SonataExporterBundle`.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
