### PR TITLE
Drop support for "symfony/*:<4.4"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,13 +27,13 @@
         "matthiasnoback/symfony-config-test": "^4.0",
         "matthiasnoback/symfony-dependency-injection-test": "^4.0",
         "propel/propel1": "^1.6",
-        "symfony/config": "^3.4 || ^4.3 || ^5.0",
-        "symfony/dependency-injection": "^3.4 || ^4.3 || ^5.0",
-        "symfony/http-foundation": "^3.4 || ^4.3 || ^5.0",
-        "symfony/http-kernel": "^3.4 || ^4.3 || ^5.0",
-        "symfony/phpunit-bridge": "^4.3.8 || ^5.0",
-        "symfony/property-access": "^3.4 || ^4.3 || ^5.0",
-        "symfony/routing": "^3.4 || ^4.3 || ^5.0"
+        "symfony/config": "^4.4 || ^5.0",
+        "symfony/dependency-injection": "^4.4 || ^5.0",
+        "symfony/http-foundation": "^4.4 || ^5.0",
+        "symfony/http-kernel": "^4.4 || ^5.0",
+        "symfony/phpunit-bridge": "^5.1",
+        "symfony/property-access": "^4.4 || ^5.0",
+        "symfony/routing": "^4.4 || ^5.0"
     },
     "suggest": {
         "propel/propel1": "To export propel collections",

--- a/src/Bridge/Symfony/DependencyInjection/Configuration.php
+++ b/src/Bridge/Symfony/DependencyInjection/Configuration.php
@@ -27,14 +27,8 @@ final class Configuration implements ConfigurationInterface
     {
         $treeBuilder = new TreeBuilder('sonata_exporter');
 
-        // Keep compatibility with symfony/config < 4.2
-        if (!method_exists($treeBuilder, 'getRootNode')) {
-            $rootNode = $treeBuilder->root('sonata_exporter');
-        } else {
-            $rootNode = $treeBuilder->getRootNode();
-        }
-
-        $rootNode
+        $treeBuilder
+            ->getRootNode()
             ->children()
                 ->arrayNode('exporter')
                     ->addDefaultsIfNotSet()


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Drop support for "symfony/*:<4.4".
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/exporter/blob/2.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because these changes respect BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/exporter/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- Removed support for "symfony/*:<4.4".
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
## To do

- [x] ~~Check if commented rules at `.doctor-rst.yaml` can be enabled.~~ This is handled by dev-kit.
