### PR TITLE
Improve rewind

### DIFF
--- a/src/Source/AbstractPropertySourceIterator.php
+++ b/src/Source/AbstractPropertySourceIterator.php
@@ -33,7 +33,7 @@ abstract class AbstractPropertySourceIterator implements SourceIteratorInterface
     ];
 
     /**
-     * @var IterableResult
+     * @var IterableResult|null
      */
     protected $iterator;
 

--- a/src/Source/DoctrineDBALConnectionSourceIterator.php
+++ b/src/Source/DoctrineDBALConnectionSourceIterator.php
@@ -15,7 +15,6 @@ namespace Sonata\Exporter\Source;
 
 use Doctrine\DBAL\Driver\Connection;
 use Doctrine\DBAL\Driver\Statement;
-use Sonata\Exporter\Exception\InvalidMethodCallException;
 
 final class DoctrineDBALConnectionSourceIterator implements SourceIteratorInterface
 {
@@ -79,10 +78,6 @@ final class DoctrineDBALConnectionSourceIterator implements SourceIteratorInterf
 
     public function rewind(): void
     {
-        if ($this->statement) {
-            throw new InvalidMethodCallException('Cannot rewind a PDOStatement');
-        }
-
         $this->statement = $this->connection->prepare($this->query);
         $this->statement->execute($this->parameters);
 

--- a/src/Source/DoctrineODMQuerySourceIterator.php
+++ b/src/Source/DoctrineODMQuerySourceIterator.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Sonata\Exporter\Source;
 
 use Doctrine\ODM\MongoDB\Query\Query;
-use Sonata\Exporter\Exception\InvalidMethodCallException;
 
 final class DoctrineODMQuerySourceIterator extends AbstractPropertySourceIterator implements SourceIteratorInterface
 {
@@ -42,10 +41,6 @@ final class DoctrineODMQuerySourceIterator extends AbstractPropertySourceIterato
 
     public function rewind(): void
     {
-        if ($this->iterator) {
-            throw new InvalidMethodCallException('Cannot rewind a Doctrine\ODM\Query');
-        }
-
         $this->iterator = $this->query->iterate();
         $this->iterator->rewind();
     }

--- a/src/Source/DoctrineORMQuerySourceIterator.php
+++ b/src/Source/DoctrineORMQuerySourceIterator.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Sonata\Exporter\Source;
 
 use Doctrine\ORM\Query;
-use Sonata\Exporter\Exception\InvalidMethodCallException;
 
 /**
  * @final since sonata-project/exporter 2.x.
@@ -49,10 +48,6 @@ class DoctrineORMQuerySourceIterator extends AbstractPropertySourceIterator impl
 
     final public function rewind(): void
     {
-        if ($this->iterator) {
-            throw new InvalidMethodCallException('Cannot rewind a Doctrine\ORM\Query');
-        }
-
         $this->iterator = $this->query->iterate();
         $this->iterator->rewind();
     }

--- a/src/Source/PropelCollectionSourceIterator.php
+++ b/src/Source/PropelCollectionSourceIterator.php
@@ -39,13 +39,10 @@ final class PropelCollectionSourceIterator extends AbstractPropertySourceIterato
 
     public function rewind(): void
     {
-        if ($this->iterator) {
-            $this->iterator->rewind();
-
-            return;
+        if (!$this->iterator) {
+            $this->iterator = $this->collection->getIterator();
         }
 
-        $this->iterator = $this->collection->getIterator();
         $this->iterator->rewind();
     }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

I am targeting this branch, because BC.

I allowed to use multiple times the `rewind` function for most of our SourceIterator.

Doctrine doesn't allow to call multiple times rewing, but since we're creating a new iterator, we just call rewing once on each iterator.

## Changelog

```markdown
### Added
- Add the ability to call the `rewind()` method multiple times for `DoctrineDBALConnectionSourceIterator`, `DoctrineODMQuerySourceIterator`, `DoctrineORMQuerySourceIterator`.
```