### PR TITLE
Fix DoctrineODMQuerySourceIterator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,12 @@
     "require": {
         "php": "^7.2"
     },
+    "conflict": {
+        "doctrine/mongodb-odm": "<2.0"
+    },
     "require-dev": {
         "doctrine/dbal": "^2.5",
+        "doctrine/mongodb-odm": "^2.0",
         "doctrine/orm": "^2.4.5",
         "matthiasnoback/symfony-config-test": "^4.0",
         "matthiasnoback/symfony-dependency-injection-test": "^4.0",

--- a/composer.json
+++ b/composer.json
@@ -29,13 +29,13 @@
         "matthiasnoback/symfony-config-test": "^4.0",
         "matthiasnoback/symfony-dependency-injection-test": "^4.0",
         "propel/propel1": "^1.6",
-        "symfony/config": "^4.4 || ^5.0",
-        "symfony/dependency-injection": "^4.4 || ^5.0",
-        "symfony/http-foundation": "^4.4 || ^5.0",
-        "symfony/http-kernel": "^4.4 || ^5.0",
-        "symfony/phpunit-bridge": "^5.1",
-        "symfony/property-access": "^4.4 || ^5.0",
-        "symfony/routing": "^4.4 || ^5.0"
+        "symfony/config": "^4.4 || ^5.1",
+        "symfony/dependency-injection": "^4.4 || ^5.1",
+        "symfony/http-foundation": "^4.4 || ^5.1",
+        "symfony/http-kernel": "^4.4 || ^5.1",
+        "symfony/phpunit-bridge": "^5.1.1",
+        "symfony/property-access": "^4.4 || ^5.1",
+        "symfony/routing": "^4.4 || ^5.1"
     },
     "suggest": {
         "propel/propel1": "To export propel collections",

--- a/src/Source/DoctrineODMQuerySourceIterator.php
+++ b/src/Source/DoctrineODMQuerySourceIterator.php
@@ -41,7 +41,7 @@ final class DoctrineODMQuerySourceIterator extends AbstractPropertySourceIterato
 
     public function rewind(): void
     {
-        $this->iterator = $this->query->iterate();
+        $this->iterator = $this->query->getIterator();
         $this->iterator->rewind();
     }
 }

--- a/src/Source/DoctrineODMQuerySourceIterator.php
+++ b/src/Source/DoctrineODMQuerySourceIterator.php
@@ -41,7 +41,10 @@ final class DoctrineODMQuerySourceIterator extends AbstractPropertySourceIterato
 
     public function rewind(): void
     {
-        $this->iterator = $this->query->getIterator();
+        if (null === $this->iterator) {
+            $this->iterator = $this->query->getIterator();
+        }
+
         $this->iterator->rewind();
     }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

[`Query::iterate` was deprecated in `doctrine/mongo-odm` `1.3`](https://github.com/doctrine/mongodb-odm/blob/1.3.x/lib/Doctrine/ODM/MongoDB/Query/Query.php#L413).

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/exporter/blob/2.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because these changes are BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/exporter/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added conflict with `doctrine/mongodb-odm` <1.3
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
