### PR TITLE
Fix redeclared class at `Sonata\Exporter\Bridge\Symfony\Bundle\SonataExporterBundle`

### DIFF
--- a/src/Bridge/Symfony/Bundle/SonataExporterBundle.php
+++ b/src/Bridge/Symfony/Bundle/SonataExporterBundle.php
@@ -13,13 +13,13 @@ declare(strict_types=1);
 
 namespace Sonata\Exporter\Bridge\Symfony\Bundle;
 
-use Sonata\Exporter\Bridge\Symfony\SonataExporterBundle;
+use Sonata\Exporter\Bridge\Symfony\SonataExporterBundle as ForwardCompatibleSonataExporterBundle;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 @trigger_error(sprintf(
     'The %s\SonataExporterBundle class is deprecated since sonata-project/exporter 2.4, to be removed in version 3.0. Use %s instead.',
     __NAMESPACE__,
-    SonataExporterBundle::class
+    ForwardCompatibleSonataExporterBundle::class
 ), E_USER_DEPRECATED);
 
 if (false) {
@@ -33,4 +33,4 @@ if (false) {
     }
 }
 
-class_alias(SonataExporterBundle::class, __NAMESPACE__.'\SonataExporterBundle');
+class_alias(ForwardCompatibleSonataExporterBundle::class, __NAMESPACE__.'\SonataExporterBundle');


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Fix redeclared class at `Sonata\Exporter\Bridge\Symfony\Bundle\SonataExporterBundle`.
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/exporter/blob/2.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this change respects BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Bug introduced at #345.
## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/exporter/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Redeclared class `Sonata\Exporter\Bridge\Symfony\Bundle\SonataExporterBundle`.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
