### PR TITLE
Use an upper bound in version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         }
     ],
     "require": {
-        "php": ">=7.3"
+        "php": "^7.3 || ^8.0"
     },
     "conflict": {
         "doctrine/mongodb-odm": "<2.0"


### PR DESCRIPTION
We cannot know for sure that this package will be compatible with PHP 9.