### PR TITLE
Fix accessing the object as array

### DIFF
--- a/src/Source/DoctrineODMQuerySourceIterator.php
+++ b/src/Source/DoctrineODMQuerySourceIterator.php
@@ -36,7 +36,7 @@ final class DoctrineODMQuerySourceIterator extends AbstractPropertySourceIterato
     {
         $current = $this->iterator->current();
 
-        $data = $this->getCurrentData($current[0]);
+        $data = $this->getCurrentData($current);
 
         $this->query->getDocumentManager()->clear();
 

--- a/tests/Source/DoctrineODMQuerySourceIteratorTest.php
+++ b/tests/Source/DoctrineODMQuerySourceIteratorTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\Exporter\Tests\Source;
+
+use Doctrine\ODM\MongoDB\Configuration;
+use Doctrine\ODM\MongoDB\DocumentManager;
+use PHPUnit\Framework\TestCase;
+use Sonata\Exporter\Source\DoctrineODMQuerySourceIterator;
+use Sonata\Exporter\Tests\Source\Fixtures\Document;
+
+final class DoctrineODMQuerySourceIteratorTest extends TestCase
+{
+    /** @var DocumentManager */
+    private $dm;
+
+    protected function setUp(): void
+    {
+        if (!\extension_loaded('mongodb')) {
+            $this->markTestSkipped('The mongodb extension is not available.');
+        }
+
+        $this->dm = DocumentManager::create(null, $this->createConfiguration());
+
+        $documentA = new Document();
+        $documentB = new Document();
+        $documentC = new Document();
+
+        $this->dm->persist($documentA);
+        $this->dm->persist($documentB);
+        $this->dm->persist($documentC);
+        $this->dm->flush();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->dm->createQueryBuilder(Document::class)
+            ->remove()
+            ->getQuery()
+            ->execute();
+    }
+
+    public function testHandler(): void
+    {
+        $query = $this->dm->createQueryBuilder(Document::class)->getQuery();
+
+        $iterator = new DoctrineODMQuerySourceIterator($query, ['id']);
+
+        $this->assertCount(3, iterator_to_array($iterator));
+    }
+
+    private function createConfiguration(): Configuration
+    {
+        $config = new Configuration();
+
+        $directory = sys_get_temp_dir().'/mongodb';
+
+        $config->setProxyDir($directory);
+        $config->setProxyNamespace('Proxies');
+        $config->setHydratorDir($directory);
+        $config->setHydratorNamespace('Hydrators');
+        $config->setPersistentCollectionDir($directory);
+        $config->setPersistentCollectionNamespace('PersistentCollections');
+        $config->setMetadataDriverImpl($config->newDefaultAnnotationDriver());
+
+        return $config;
+    }
+}

--- a/tests/Source/Fixtures/Document.php
+++ b/tests/Source/Fixtures/Document.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\Exporter\Tests\Source\Fixtures;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+/** @ODM\Document */
+class Document
+{
+    /**
+     * @ODM\Id
+     *
+     * @var string
+     */
+    private $id;
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

When using MongoDB, IterableResult::current() method returns the current document, not an array.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/exporter/blob/2.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is a bugfix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #452.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/exporter/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed iterating over documents when using `DoctrineODMQuerySourceIterator`.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->

Can you please try it @webdevilopers?