### PR TITLE
Fix phpdoc of AbstractPropertySourceIterator::getValue

### DIFF
--- a/src/Source/AbstractPropertySourceIterator.php
+++ b/src/Source/AbstractPropertySourceIterator.php
@@ -155,7 +155,7 @@ abstract class AbstractPropertySourceIterator implements SourceIteratorInterface
     /**
      * @param mixed $value
      *
-     * @return string|null
+     * @return bool|int|float|string|null
      */
     protected function getValue($value)
     {


### PR DESCRIPTION
## Subject

I am targeting this branch, because patch.

For instance, Excel is handling differently string and float values ; so we should not restrict the value to be string.

## Changelog

```markdown
### Fixed
- Allow `AbstractPropertySourceIterator::getValue()` to return `bool|int|float` value.
```