### PR TITLE
Improve ORM iterator performances

### DIFF
--- a/src/Source/DoctrineORMQuerySourceIterator.php
+++ b/src/Source/DoctrineORMQuerySourceIterator.php
@@ -26,15 +26,22 @@ class DoctrineORMQuerySourceIterator extends AbstractPropertySourceIterator impl
     protected $query;
 
     /**
+     * @var int
+     */
+    private $batchSize;
+
+    /**
      * @param array<string> $fields Fields to export
      */
-    public function __construct(Query $query, array $fields, string $dateTimeFormat = 'r')
+    public function __construct(Query $query, array $fields, string $dateTimeFormat = 'r', int $batchSize = 100)
     {
         $this->query = clone $query;
         $this->query->setParameters($query->getParameters());
         foreach ($query->getHints() as $name => $value) {
             $this->query->setHint($name, $value);
         }
+
+        $this->batchSize = $batchSize;
 
         parent::__construct($fields, $dateTimeFormat);
     }
@@ -45,7 +52,9 @@ class DoctrineORMQuerySourceIterator extends AbstractPropertySourceIterator impl
 
         $data = $this->getCurrentData($current[0]);
 
-        $this->query->getEntityManager()->clear();
+        if (0 === ($this->iterator->key() % $this->batchSize)) {
+            $this->query->getEntityManager()->clear();
+        }
 
         return $data;
     }

--- a/tests/Source/DoctrineORMQuerySourceIteratorTest.php
+++ b/tests/Source/DoctrineORMQuerySourceIteratorTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\Exporter\Tests\Source;
+
+use Doctrine\Common\Annotations\AnnotationReader;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Driver;
+use Doctrine\ORM\Configuration;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
+use Doctrine\ORM\Tools\SchemaTool;
+use Doctrine\Persistence\Mapping\Driver\MappingDriver;
+use PHPUnit\Framework\TestCase;
+use Sonata\Exporter\Source\DoctrineORMQuerySourceIterator;
+use Sonata\Exporter\Tests\Source\Fixtures\Entity;
+
+final class DoctrineORMQuerySourceIteratorTest extends TestCase
+{
+    /** @var EntityManager */
+    private $em;
+
+    protected function setUp(): void
+    {
+        if (!\extension_loaded('pdo_sqlite') || !class_exists(Driver\PDO\SQLite\Driver::class)) {
+            $this->markTestSkipped('The sqlite extension is not available.');
+        }
+
+        $this->em = EntityManager::create($this->createConnection(), $this->createConfiguration());
+
+        $schemaTool = new SchemaTool($this->em);
+        $schemaTool->dropDatabase();
+        $schemaTool->createSchema([
+            $this->em->getClassMetadata(Entity::class),
+        ]);
+
+        $entityA = new Entity();
+        $entityB = new Entity();
+        $entityC = new Entity();
+
+        $this->em->persist($entityA);
+        $this->em->persist($entityB);
+        $this->em->persist($entityC);
+        $this->em->flush();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->em
+            ->createQuery('DELETE FROM '.Entity::class)
+            ->execute();
+    }
+
+    public function testEntityManagerClear(): void
+    {
+        $query = $this->em
+            ->getRepository(Entity::class)
+            ->createQueryBuilder('e')
+            ->getQuery();
+
+        $batchSize = 2;
+        $iterator = new DoctrineORMQuerySourceIterator($query, ['id'], 'r', $batchSize);
+
+        foreach ($iterator as $i => $item) {
+            $this->assertSame(0 === $i % $batchSize ? 0 : $i, $this->em->getUnitOfWork()->size());
+        }
+    }
+
+    private function createConnection(): Connection
+    {
+        return new Connection([], new Driver\PDO\SQLite\Driver());
+    }
+
+    private function createConfiguration(): Configuration
+    {
+        $config = new Configuration();
+
+        $directory = sys_get_temp_dir().'/sqlite';
+
+        $config->setProxyDir($directory);
+        $config->setProxyNamespace('Proxies');
+        $config->setMetadataDriverImpl($this->createMetadataDriverImplementation());
+
+        return $config;
+    }
+
+    private function createMetadataDriverImplementation(): MappingDriver
+    {
+        return new AnnotationDriver(new AnnotationReader());
+    }
+}

--- a/tests/Source/Fixtures/Entity.php
+++ b/tests/Source/Fixtures/Entity.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\Exporter\Tests\Source\Fixtures;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/** @ORM\Entity */
+class Entity
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue(strategy="AUTO")
+     *
+     * @var int
+     */
+    private $id;
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+}


### PR DESCRIPTION
## Add a batch size for entity manager clear

Clearing the entity manager at each result leads to very poor performances. Using a batch size of 100 seems reasonnable to keep good performances and memory under control.

I am targeting this branch, because it's a BC performance fix.

## Changelog
```markdown
- Clear entity manager every 100 results to improve ORM iterator performances
```