### PR TITLE
docs: symfony example with exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ composer require sonata-project/exporter
 
 ## Usage
 
+### Standalone
+
 ```php
 <?php
 
@@ -42,6 +44,30 @@ $writer = new CsvWriter('data.csv');
 
 // Export the data
 Handler::create($source, $writer)->export();
+```
+
+### Symfony bridge
+
+You can directly return an export as a streamed response like this:
+
+```php
+final class InvoicesExport
+{
+    /**
+     * @Route("/invoices", name="invoices_export")
+     */
+    public function __invoke(Request $request, Exporter $exporter): Response
+    {
+        $invoices = $this->getMyInvoices();
+        $format = $request->getRequestFormat();
+    
+        return $exporter->getResponse(
+            $format,
+            'invoices.'.$format,
+            new ArraySourceIterator($invoices)
+        );
+    }
+}
 ```
 
 ## Documentation


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/exporter/blob/2.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because the only usage we have is for the standalone library directly using the writer.

However, we have a much more simple way to implement an export HTTP response thanks to the exporter service, but I see no example about it.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

