### PR TITLE
Bump phpstan to level 2

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -2,7 +2,7 @@ includes:
     - phpstan-baseline.neon
 
 parameters:
-    level: 1
+    level: 2
     bootstrapFiles:
         - vendor/bin/.phpunit/phpunit/vendor/autoload.php
     paths:

--- a/src/Source/DoctrineORMQuerySourceIterator.php
+++ b/src/Source/DoctrineORMQuerySourceIterator.php
@@ -50,7 +50,7 @@ class DoctrineORMQuerySourceIterator extends AbstractPropertySourceIterator impl
     {
         $current = $this->iterator->current();
 
-        $data = $this->getCurrentData($current[0]);
+        $data = $this->getCurrentData($current);
 
         if (0 === ($this->iterator->key() % $this->batchSize)) {
             $this->query->getEntityManager()->clear();
@@ -61,7 +61,19 @@ class DoctrineORMQuerySourceIterator extends AbstractPropertySourceIterator impl
 
     final public function rewind(): void
     {
-        $this->iterator = $this->query->iterate();
+        $this->iterator = $this->iterableToIterator($this->query->toIterable());
         $this->iterator->rewind();
+    }
+
+    private function iterableToIterator(iterable $iterable): \Iterator
+    {
+        if ($iterable instanceof \Iterator) {
+            return $iterable;
+        }
+        if (\is_array($iterable)) {
+            return new \ArrayIterator($iterable);
+        }
+
+        return new \ArrayIterator(iterator_to_array($iterable));
     }
 }

--- a/src/Source/PropelCollectionSourceIterator.php
+++ b/src/Source/PropelCollectionSourceIterator.php
@@ -39,7 +39,7 @@ final class PropelCollectionSourceIterator extends AbstractPropertySourceIterato
 
     public function rewind(): void
     {
-        if (!$this->iterator) {
+        if (null === $this->iterator) {
             $this->iterator = $this->collection->getIterator();
         }
 

--- a/src/Source/SourceIteratorInterface.php
+++ b/src/Source/SourceIteratorInterface.php
@@ -14,8 +14,7 @@ declare(strict_types=1);
 namespace Sonata\Exporter\Source;
 
 /**
- * @phpstan-template T of array
- * @phpstan-extends \Iterator<T>
+ * @phpstan-extends \Iterator<array<mixed>>
  */
 interface SourceIteratorInterface extends \Iterator
 {

--- a/src/Writer/GsaFeedWriter.php
+++ b/src/Writer/GsaFeedWriter.php
@@ -48,7 +48,7 @@ final class GsaFeedWriter implements WriterInterface
     private $bufferPart;
 
     /**
-     * @var resource
+     * @var resource|null
      */
     private $buffer;
 
@@ -97,7 +97,7 @@ final class GsaFeedWriter implements WriterInterface
 
     public function close(): void
     {
-        if ($this->buffer) {
+        if (null !== $this->buffer) {
             $this->closeFeed();
         }
     }
@@ -109,7 +109,7 @@ final class GsaFeedWriter implements WriterInterface
      */
     private function generateNewPart(): void
     {
-        if ($this->buffer) {
+        if (null !== $this->buffer) {
             $this->closeFeed();
         }
 

--- a/src/Writer/SitemapWriter.php
+++ b/src/Writer/SitemapWriter.php
@@ -42,7 +42,7 @@ final class SitemapWriter implements WriterInterface
     private $autoIndex;
 
     /**
-     * @var resource
+     * @var resource|null
      */
     private $buffer;
 
@@ -79,7 +79,7 @@ final class SitemapWriter implements WriterInterface
         $this->headers = $headers;
         $this->autoIndex = $autoIndex;
 
-        $this->pattern = 'sitemap_'.($this->groupName ? $this->groupName.'_' : '').'%05d.xml';
+        $this->pattern = 'sitemap_'.('' !== $this->groupName ? $this->groupName.'_' : '').'%05d.xml';
     }
 
     /**
@@ -129,15 +129,15 @@ final class SitemapWriter implements WriterInterface
 
     public function close(): void
     {
-        if ($this->buffer) {
+        if (null !== $this->buffer) {
             $this->closeSitemap();
         }
 
         if ($this->autoIndex) {
             self::generateSitemapIndex(
                 $this->folder,
-                'sitemap_'.($this->groupName ? $this->groupName.'_' : '').'*.xml',
-                'sitemap'.($this->groupName ? '_'.$this->groupName : '').'.xml'
+                'sitemap_'.('' !== $this->groupName ? $this->groupName.'_' : '').'*.xml',
+                'sitemap'.('' !== $this->groupName ? '_'.$this->groupName : '').'.xml'
             );
         }
     }
@@ -175,7 +175,7 @@ final class SitemapWriter implements WriterInterface
      */
     private function generateNewPart(): void
     {
-        if ($this->buffer) {
+        if (null !== $this->buffer) {
             $this->closeSitemap();
         }
 
@@ -238,7 +238,7 @@ final class SitemapWriter implements WriterInterface
      * Fix type of data, if data type is specific,
      * he must to be defined in data and he must to be a array.
      *
-     * @param array &$data List of parameters
+     * @param array $data List of parameters
      */
     private function fixDataType(array &$data): void
     {

--- a/tests/Source/PDOStatementSourceIteratorTest.php
+++ b/tests/Source/PDOStatementSourceIteratorTest.php
@@ -58,7 +58,7 @@ class PDOStatementSourceIteratorTest extends TestCase
 
     protected function tearDown(): void
     {
-        $this->dbh = null;
+        unset($this->dbh);
 
         if (is_file($this->pathToDb)) {
             unlink($this->pathToDb);


### PR DESCRIPTION
## Subject

BC, except for the static analysis.
But a generic array-shape is not supported by phpstan, so this wasn't fully working anymore.
Better to remove the template and then fix the static analysis in SonataAdmin.

Also Closes #459.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- `SourceIteratorInterface` is not generic anymore

### Fixed
- doctrine/orm deprecation
```