### PR TITLE
Deprecate SourceIteratorInterface

### DIFF
--- a/src/Source/SourceIteratorInterface.php
+++ b/src/Source/SourceIteratorInterface.php
@@ -14,6 +14,10 @@ declare(strict_types=1);
 namespace Sonata\Exporter\Source;
 
 /**
+ * NEXT_MAJOR: Remove this interface.
+ *
+ * @deprecated since 2.x use \Iterator instead.
+ *
  * @phpstan-extends \Iterator<array<mixed>>
  */
 interface SourceIteratorInterface extends \Iterator


### PR DESCRIPTION
## Subject

I am targeting this branch, because BC.

Discussion started here: https://github.com/sonata-project/SonataSeoBundle/pull/606#discussion_r718754196
I don't see the benefit of this interface, it seems better to me to use the generic `\Iterator` one.

## Changelog

```markdown
### Deprecated
- `SourceIteratorInterface`
```