### PR TITLE
Add conflict with doctrine/orm < 2.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,13 +24,14 @@
         "php": "^7.3 || ^8.0"
     },
     "conflict": {
-        "doctrine/mongodb-odm": "<2.0"
+        "doctrine/mongodb-odm": "<2.0",
+        "doctrine/orm": "<2.8"
     },
     "require-dev": {
         "doctrine/annotations": "^1.13",
-        "doctrine/dbal": "^2.5",
+        "doctrine/dbal": "^2.10",
         "doctrine/mongodb-odm": "^2.0",
-        "doctrine/orm": "^2.4.5",
+        "doctrine/orm": "^2.8",
         "matthiasnoback/symfony-config-test": "^4.2",
         "matthiasnoback/symfony-dependency-injection-test": "^4.0",
         "phpstan/extension-installer": "^1.0",


### PR DESCRIPTION
## Subject

Related to https://github.com/sonata-project/exporter/issues/459#issuecomment-931399875

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Added missing conflict with doctrine/orm < 2.8
```