### PR TITLE
Add a batch size for document manager clear

### DIFF
--- a/src/Source/DoctrineODMQuerySourceIterator.php
+++ b/src/Source/DoctrineODMQuerySourceIterator.php
@@ -23,11 +23,18 @@ final class DoctrineODMQuerySourceIterator extends AbstractPropertySourceIterato
     private $query;
 
     /**
+     * @var int
+     */
+    private $batchSize;
+
+    /**
      * @param array<string> $fields Fields to export
      */
-    public function __construct(Query $query, array $fields, string $dateTimeFormat = 'r')
+    public function __construct(Query $query, array $fields, string $dateTimeFormat = 'r', int $batchSize = 100)
     {
         $this->query = clone $query;
+
+        $this->batchSize = $batchSize;
 
         parent::__construct($fields, $dateTimeFormat);
     }
@@ -41,7 +48,9 @@ final class DoctrineODMQuerySourceIterator extends AbstractPropertySourceIterato
 
         $data = $this->getCurrentData($current);
 
-        $this->query->getDocumentManager()->clear();
+        if (0 === ($this->iterator->key() % $this->batchSize)) {
+            $this->query->getDocumentManager()->clear();
+        }
 
         return $data;
     }

--- a/tests/Source/DoctrineODMQuerySourceIteratorTest.php
+++ b/tests/Source/DoctrineODMQuerySourceIteratorTest.php
@@ -59,6 +59,18 @@ final class DoctrineODMQuerySourceIteratorTest extends TestCase
         static::assertCount(3, iterator_to_array($iterator));
     }
 
+    public function testEntityManagerClear(): void
+    {
+        $query = $this->dm->createQueryBuilder(Document::class)->getQuery();
+
+        $batchSize = 2;
+        $iterator = new DoctrineODMQuerySourceIterator($query, ['id'], 'r', $batchSize);
+
+        foreach ($iterator as $i => $item) {
+            static::assertSame(0 === $i % $batchSize ? 0 : $i, $this->dm->getUnitOfWork()->size());
+        }
+    }
+
     private function createConfiguration(): Configuration
     {
         $config = new Configuration();


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Add a batch size for document manager clear

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - 3.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/exporter/blob/2.x/CONTRIBUTING.md#base-branch
-->
Clearing the document manager at each result leads to very poor performances. Using a batch size of 100 seems reasonnable to keep good performances and memory under control.

Same as https://github.com/sonata-project/exporter/pull/485 but for ODM instead of ORM.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/exporter/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown

### Changed
- Clear document manager every 100 results to improve ODM iterator performances

```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
