### PR TITLE
Solve deprecation about SourceIteratorInterface

### DIFF
--- a/docs/reference/introduction.rst
+++ b/docs/reference/introduction.rst
@@ -10,7 +10,7 @@ Usage
 
 .. code-block:: php
 
-    // This can be any instance of SourceIteratorInterface
+    // This can be any instance of \Iterator
     $source = new ArraySourceIterator([/* your data */]);
 
     // This could be any format supported

--- a/docs/reference/sources.rst
+++ b/docs/reference/sources.rst
@@ -17,5 +17,4 @@ You may export data from various sources:
 * Sitemap (Takes another iterator)
 * Chain (can aggregate data from several different iterators)
 
-You may also create your own. To do so, create a class that implements ``Exporter\Source\SourceIteratorInterface``.
-
+You may also create your own. To do so, create a class that implements ``\Iterator``.

--- a/src/Exporter.php
+++ b/src/Exporter.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Sonata\Exporter;
 
-use Sonata\Exporter\Source\SourceIteratorInterface;
 use Sonata\Exporter\Writer\TypedWriterInterface;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
@@ -42,7 +41,7 @@ final class Exporter
     /**
      * @throws \RuntimeException
      */
-    public function getResponse(string $format, string $filename, SourceIteratorInterface $source): StreamedResponse
+    public function getResponse(string $format, string $filename, \Iterator $source): StreamedResponse
     {
         if (!\array_key_exists($format, $this->writers)) {
             throw new \RuntimeException(sprintf(

--- a/src/Handler.php
+++ b/src/Handler.php
@@ -13,13 +13,12 @@ declare(strict_types=1);
 
 namespace Sonata\Exporter;
 
-use Sonata\Exporter\Source\SourceIteratorInterface;
 use Sonata\Exporter\Writer\WriterInterface;
 
 final class Handler
 {
     /**
-     * @var SourceIteratorInterface
+     * @var \Iterator
      */
     private $source;
 
@@ -28,7 +27,7 @@ final class Handler
      */
     private $writer;
 
-    public function __construct(SourceIteratorInterface $source, WriterInterface $writer)
+    public function __construct(\Iterator $source, WriterInterface $writer)
     {
         $this->source = $source;
         $this->writer = $writer;
@@ -45,7 +44,7 @@ final class Handler
         $this->writer->close();
     }
 
-    public static function create(SourceIteratorInterface $source, WriterInterface $writer): self
+    public static function create(\Iterator $source, WriterInterface $writer): self
     {
         return new self($source, $writer);
     }

--- a/src/Source/ChainSourceIterator.php
+++ b/src/Source/ChainSourceIterator.php
@@ -16,12 +16,12 @@ namespace Sonata\Exporter\Source;
 final class ChainSourceIterator implements SourceIteratorInterface
 {
     /**
-     * @var \ArrayIterator<array-key, SourceIteratorInterface>
+     * @var \ArrayIterator<array-key, \Iterator>
      */
     private $sources;
 
     /**
-     * @param array<SourceIteratorInterface> $sources
+     * @param array<\Iterator> $sources
      */
     public function __construct(array $sources = [])
     {
@@ -32,7 +32,7 @@ final class ChainSourceIterator implements SourceIteratorInterface
         }
     }
 
-    public function addSource(SourceIteratorInterface $source): void
+    public function addSource(\Iterator $source): void
     {
         $this->sources->append($source);
     }

--- a/src/Source/SymfonySitemapSourceIterator.php
+++ b/src/Source/SymfonySitemapSourceIterator.php
@@ -24,7 +24,7 @@ final class SymfonySitemapSourceIterator implements SourceIteratorInterface
     private $router;
 
     /**
-     * @var SourceIteratorInterface
+     * @var \Iterator
      */
     private $source;
 
@@ -39,7 +39,7 @@ final class SymfonySitemapSourceIterator implements SourceIteratorInterface
     private $parameters;
 
     public function __construct(
-        SourceIteratorInterface $source,
+        \Iterator $source,
         RouterInterface $router,
         string $routeName,
         array $parameters = []

--- a/tests/ExporterTest.php
+++ b/tests/ExporterTest.php
@@ -16,7 +16,6 @@ namespace Sonata\Exporter\Tests;
 use PHPUnit\Framework\TestCase;
 use Sonata\Exporter\Exporter;
 use Sonata\Exporter\Source\ArraySourceIterator;
-use Sonata\Exporter\Source\SourceIteratorInterface;
 use Sonata\Exporter\Writer\CsvWriter;
 use Sonata\Exporter\Writer\JsonWriter;
 use Sonata\Exporter\Writer\TypedWriterInterface;
@@ -30,7 +29,7 @@ final class ExporterTest extends TestCase
     {
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('Invalid "foo" format');
-        $source = $this->createMock(SourceIteratorInterface::class);
+        $source = $this->createMock(\Iterator::class);
         $writer = $this->createMock(TypedWriterInterface::class);
 
         $exporter = new Exporter([$writer]);

--- a/tests/HandlerTest.php
+++ b/tests/HandlerTest.php
@@ -11,18 +11,17 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace Sonata\Exporter\Test;
+namespace Sonata\Exporter\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\Exporter\Handler;
-use Sonata\Exporter\Source\SourceIteratorInterface;
 use Sonata\Exporter\Writer\WriterInterface;
 
 final class HandlerTest extends TestCase
 {
     public function testHandler(): void
     {
-        $source = $this->createMock(SourceIteratorInterface::class);
+        $source = $this->createMock(\Iterator::class);
         $writer = $this->createMock(WriterInterface::class);
         $writer->expects(static::once())->method('open');
         $writer->expects(static::once())->method('close');

--- a/tests/Source/ChainSourceIteratorTest.php
+++ b/tests/Source/ChainSourceIteratorTest.php
@@ -15,7 +15,6 @@ namespace Sonata\Exporter\Tests\Source;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\Exporter\Source\ChainSourceIterator;
-use Sonata\Exporter\Source\SourceIteratorInterface;
 
 final class ChainSourceIteratorTest extends TestCase
 {
@@ -24,7 +23,7 @@ final class ChainSourceIteratorTest extends TestCase
      */
     public function testIterator(): void
     {
-        $source = $this->createMock(SourceIteratorInterface::class);
+        $source = $this->createMock(\Iterator::class);
 
         $iterator = new ChainSourceIterator([$source]);
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

I am targeting this branch, because BC since classes are final.

Closes #552.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Some typehint from SourceIteratorInterface to \Iterator to allow using this library without deprecation.
```