### PR TITLE
Deprecate custom flex bundle file

### DIFF
--- a/src/Bridge/Symfony/SonataExporterSymfonyBundle.php
+++ b/src/Bridge/Symfony/SonataExporterSymfonyBundle.php
@@ -13,8 +13,10 @@ declare(strict_types=1);
 
 namespace Sonata\Exporter\Bridge\Symfony;
 
-// This file and its class alias is required in order to let Symfony Flex
-// autodiscovery to find the bundle.
-// The string "Symfony\Component\HttpKernel\Bundle\Bundle" must also be present.
-// @see https://github.com/symfony/flex/pull/612/files.
+@trigger_error(sprintf(
+    'The %s\SonataExporterSymfonyBundle class is deprecated since sonata-project/exporter 2.x, to be removed in version 3.0. Use %s instead.',
+    __NAMESPACE__,
+    SonataExporterBundle::class
+), \E_USER_DEPRECATED);
+
 class_alias(SonataExporterBundle::class, __NAMESPACE__.'\SonataExporterSymfonyBundle');


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - 3.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/exporter/blob/2.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/exporter/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- Deprecated custom bundle file for flex recipe.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
