### PR TITLE
Deprecate passing a DriverConnection

### DIFF
--- a/src/Source/DoctrineDBALConnectionSourceIterator.php
+++ b/src/Source/DoctrineDBALConnectionSourceIterator.php
@@ -51,6 +51,15 @@ final class DoctrineDBALConnectionSourceIterator implements SourceIteratorInterf
     public function __construct($connection, string $query, array $parameters = [])
     {
         if (!$connection instanceof Connection) {
+            if (!$connection instanceof DriverConnection) {
+                throw new \TypeError(sprintf(
+                    '%s: Argument 1 is expected to be an instance of %s, got %s.',
+                    __METHOD__,
+                    Connection::class,
+                    \get_class($connection)
+                ));
+            }
+
             @trigger_error(sprintf(
                 'Passing an instance of %s as argument 1 is deprecated since sonata-project/exporter 2.13'
                 .' and will not work in 3.0. You MUST pass an instance of %s instead',

--- a/tests/Source/DoctrineDBALConnectionSourceIteratorTest.php
+++ b/tests/Source/DoctrineDBALConnectionSourceIteratorTest.php
@@ -30,6 +30,21 @@ final class DoctrineDBALConnectionSourceIteratorTest extends TestCase
     public function testRewindWithEmptyQuery(): void
     {
         $connection = DriverManager::getConnection(['url' => 'sqlite:///:memory:']);
+
+        $iterator = new DoctrineDBALConnectionSourceIterator($connection, ' ');
+        $iterator->rewind();
+
+        static::assertCount(0, iterator_to_array($iterator));
+    }
+
+    /**
+     * NEXT_MAJOR: Remove this test.
+     *
+     * @group legacy
+     */
+    public function testRewindWithEmptyQueryAndDeprecatedConnection(): void
+    {
+        $connection = DriverManager::getConnection(['url' => 'sqlite:///:memory:']);
         $driverConnection = $connection->getWrappedConnection();
 
         $iterator = new DoctrineDBALConnectionSourceIterator($driverConnection, ' ');


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Related to the deprecation in dbal https://github.com/doctrine/dbal/pull/4966

It will work this way in 3.x https://github.com/sonata-project/exporter/pull/594

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/exporter/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- Passing  an instance of `Doctrine\DBAL\Driver\Connection` to `DoctrineDBALConnectionSourceIterator::__construct()`
```