### PR TITLE
Added ExporterInterface

### DIFF
--- a/src/Exporter.php
+++ b/src/Exporter.php
@@ -19,7 +19,7 @@ use Symfony\Component\HttpFoundation\StreamedResponse;
 /**
  * @author Grégoire Paris <postmaster@greg0ire.fr>
  */
-final class Exporter
+final class Exporter implements ExporterInterface
 {
     /**
      * @var array<TypedWriterInterface>

--- a/src/ExporterInterface.php
+++ b/src/ExporterInterface.php
@@ -2,6 +2,15 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Sonata\Exporter;
 
 use Symfony\Component\HttpFoundation\StreamedResponse;

--- a/src/ExporterInterface.php
+++ b/src/ExporterInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sonata\Exporter;
+
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+interface ExporterInterface
+{
+    /**
+     * @return string[]
+     */
+    public function getAvailableFormats(): array;
+
+    public function getResponse(string $format, string $filename, \Iterator $source): StreamedResponse;
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - 4.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/exporter/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because we need to follow dependence inversion principle. CRUDController in sonata-project/SonataAdminBundle shouldn't depend on Exporter class, but on ExporterInterface

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/exporter/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added ExporterInterface;
- Added implementation ExporterInterface by Exporter.
```

