### PR TITLE
Allow to extract values from enum types at `AbstractPropertySourceIterator::getValue()`

### DIFF
--- a/src/Source/AbstractPropertySourceIterator.php
+++ b/src/Source/AbstractPropertySourceIterator.php
@@ -43,7 +43,8 @@ abstract class AbstractPropertySourceIterator implements \Iterator
      */
     public function __construct(
         protected array $fields,
-        protected string $dateTimeFormat = 'r'
+        protected string $dateTimeFormat = 'r',
+        protected bool $useBackedEnumValue = true
     ) {
         $this->propertyAccessor = PropertyAccess::createPropertyAccessor();
     }
@@ -83,6 +84,16 @@ abstract class AbstractPropertySourceIterator implements \Iterator
     public function getDateTimeFormat(): string
     {
         return $this->dateTimeFormat;
+    }
+
+    public function useBackedEnumValue(bool $useBackedEnumValue): void
+    {
+        $this->useBackedEnumValue = $useBackedEnumValue;
+    }
+
+    public function isBackedEnumValueInUse(): bool
+    {
+        return $this->useBackedEnumValue;
     }
 
     protected function getIterator(): \Iterator
@@ -126,6 +137,8 @@ abstract class AbstractPropertySourceIterator implements \Iterator
             $value instanceof \Traversable => '['.implode(', ', array_map([$this, 'getValue'], iterator_to_array($value))).']',
             $value instanceof \DateTimeInterface => $value->format($this->dateTimeFormat),
             $value instanceof \DateInterval => $this->getDuration($value),
+            $value instanceof \BackedEnum && $this->useBackedEnumValue => $value->value,
+            $value instanceof \UnitEnum => $value->name,
             \is_object($value) => method_exists($value, '__toString') ? (string) $value : null,
             default => $value,
         };

--- a/src/Source/DoctrineODMQuerySourceIterator.php
+++ b/src/Source/DoctrineODMQuerySourceIterator.php
@@ -26,11 +26,12 @@ final class DoctrineODMQuerySourceIterator extends AbstractPropertySourceIterato
         Query $query,
         array $fields,
         string $dateTimeFormat = \DateTimeInterface::ATOM,
-        private int $batchSize = 100
+        private int $batchSize = 100,
+        bool $useBackedEnumValue = true
     ) {
         $this->query = clone $query;
 
-        parent::__construct($fields, $dateTimeFormat);
+        parent::__construct($fields, $dateTimeFormat, $useBackedEnumValue);
     }
 
     /**

--- a/src/Source/DoctrineORMQuerySourceIterator.php
+++ b/src/Source/DoctrineORMQuerySourceIterator.php
@@ -26,7 +26,8 @@ final class DoctrineORMQuerySourceIterator extends AbstractPropertySourceIterato
         Query $query,
         array $fields,
         string $dateTimeFormat = 'r',
-        private int $batchSize = 100
+        private int $batchSize = 100,
+        bool $useBackedEnumValue = true,
     ) {
         $this->query = clone $query;
         $this->query->setParameters($query->getParameters());
@@ -34,7 +35,7 @@ final class DoctrineORMQuerySourceIterator extends AbstractPropertySourceIterato
             $this->query->setHint($name, $value);
         }
 
-        parent::__construct($fields, $dateTimeFormat);
+        parent::__construct($fields, $dateTimeFormat, $useBackedEnumValue);
     }
 
     /**

--- a/tests/Source/AbstractPropertySourceIteratorTest.php
+++ b/tests/Source/AbstractPropertySourceIteratorTest.php
@@ -15,16 +15,18 @@ namespace Sonata\Exporter\Tests\Source;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\Exporter\Source\AbstractPropertySourceIterator;
+use Sonata\Exporter\Tests\Source\Fixtures\Element;
 use Sonata\Exporter\Tests\Source\Fixtures\ObjectWithToString;
+use Sonata\Exporter\Tests\Source\Fixtures\Suit;
 
 final class AbstractPropertySourceIteratorTest extends TestCase
 {
     /**
      * @dataProvider provideGetValueCases
      */
-    public function testGetValue(mixed $value, mixed $expected, string $dateFormat = 'r'): void
+    public function testGetValue(mixed $value, mixed $expected, string $dateFormat = 'r', bool $useBackedEnumValue = true): void
     {
-        $iterator = new class([], $dateFormat) extends AbstractPropertySourceIterator {
+        $iterator = new class([], $dateFormat, $useBackedEnumValue) extends AbstractPropertySourceIterator {
             public function rewind(): void
             {
                 $this->iterator = new \ArrayIterator();
@@ -41,39 +43,43 @@ final class AbstractPropertySourceIteratorTest extends TestCase
     }
 
     /**
-     * @return iterable<array{0: mixed, 1: mixed, 2?: string}>
+     * @return iterable<array{0: mixed, 1: mixed, 2?: string, 3?: bool}>
      */
     public function provideGetValueCases(): iterable
     {
         $datetime = new \DateTime();
         $dateTimeImmutable = new \DateTimeImmutable();
 
-        $data = [
-            [[1, 2, 3], '[1, 2, 3]'],
-            [new \ArrayIterator([1, 2, 3]), '[1, 2, 3]'],
-            [(static function (): \Generator { yield from [1, 2, 3]; })(), '[1, 2, 3]'],
-            [$datetime, $datetime->format('r')],
-            [$datetime, $datetime->format('Y-m-d H:i:s'), 'Y-m-d H:i:s'],
-            [123, 123],
-            ['123', '123'],
-            [new ObjectWithToString('object with to string'), 'object with to string'],
-            [$dateTimeImmutable, $dateTimeImmutable->format('r')],
-            [$dateTimeImmutable, $dateTimeImmutable->format('Y-m-d H:i:s'), 'Y-m-d H:i:s'],
-            [new \DateInterval('P1Y'), 'P1Y'],
-            [new \DateInterval('P1M'), 'P1M'],
-            [new \DateInterval('P1D'), 'P1D'],
-            [new \DateInterval('PT1H'), 'PT1H'],
-            [new \DateInterval('PT1M'), 'PT1M'],
-            [new \DateInterval('PT1S'), 'PT1S'],
-            [new \DateInterval('P1Y1M'), 'P1Y1M'],
-            [new \DateInterval('P1Y1M1D'), 'P1Y1M1D'],
-            [new \DateInterval('P1Y1M1DT1H'), 'P1Y1M1DT1H'],
-            [new \DateInterval('P1Y1M1DT1H1M'), 'P1Y1M1DT1H1M'],
-            [new \DateInterval('P1Y1M1DT1H1M1S'), 'P1Y1M1DT1H1M1S'],
-            [new \DateInterval('P0Y'), 'P0Y'],
-            [new \DateInterval('PT0S'), 'P0Y'],
-        ];
+        yield [[1, 2, 3], '[1, 2, 3]'];
+        yield [new \ArrayIterator([1, 2, 3]), '[1, 2, 3]'];
+        yield [(static function (): \Generator { yield from [1, 2, 3]; })(), '[1, 2, 3]'];
+        yield [$datetime, $datetime->format('r')];
+        yield [$datetime, $datetime->format('Y-m-d H:i:s'), 'Y-m-d H:i:s'];
+        yield [123, 123];
+        yield ['123', '123'];
+        yield [new ObjectWithToString('object with to string'), 'object with to string'];
+        yield [$dateTimeImmutable, $dateTimeImmutable->format('r')];
+        yield [$dateTimeImmutable, $dateTimeImmutable->format('Y-m-d H:i:s'), 'Y-m-d H:i:s'];
+        yield [new \DateInterval('P1Y'), 'P1Y'];
+        yield [new \DateInterval('P1M'), 'P1M'];
+        yield [new \DateInterval('P1D'), 'P1D'];
+        yield [new \DateInterval('PT1H'), 'PT1H'];
+        yield [new \DateInterval('PT1M'), 'PT1M'];
+        yield [new \DateInterval('PT1S'), 'PT1S'];
+        yield [new \DateInterval('P1Y1M'), 'P1Y1M'];
+        yield [new \DateInterval('P1Y1M1D'), 'P1Y1M1D'];
+        yield [new \DateInterval('P1Y1M1DT1H'), 'P1Y1M1DT1H'];
+        yield [new \DateInterval('P1Y1M1DT1H1M'), 'P1Y1M1DT1H1M'];
+        yield [new \DateInterval('P1Y1M1DT1H1M1S'), 'P1Y1M1DT1H1M1S'];
+        yield [new \DateInterval('P0Y'), 'P0Y'];
+        yield [new \DateInterval('PT0S'), 'P0Y'];
 
-        return $data;
+        if (\PHP_VERSION_ID < 80100) {
+            return;
+        }
+
+        yield [Element::Hydrogen, 'Hydrogen'];
+        yield [Suit::Diamonds, 'D'];
+        yield [Suit::Diamonds, 'Diamonds', 'r', false];
     }
 }

--- a/tests/Source/Fixtures/Element.php
+++ b/tests/Source/Fixtures/Element.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\Exporter\Tests\Source\Fixtures;
+
+enum Element
+{
+    case Carbon;
+    case Helium;
+    case Hydrogen;
+    case Lithium;
+}

--- a/tests/Source/Fixtures/Suit.php
+++ b/tests/Source/Fixtures/Suit.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\Exporter\Tests\Source\Fixtures;
+
+enum Suit: string
+{
+    case Clubs = 'C';
+    case Diamonds = 'D';
+    case Hearts = 'H';
+    case Spades = 'S';
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Allow to extract values from enum types at `AbstractPropertySourceIterator::getValue()`
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - 4.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/exporter/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this change respects BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: https://keepachangelog.com/
    This will end up on https://github.com/sonata-project/exporter/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS
    - Don't repeat the verb in the messages (don't use "Added", "Changed", etc).
    - Don't use a full stop at the end of the messages.
-->
```markdown
### Added
- Support for enum types in exported values.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
