### PR TITLE
Allow phpoffice/phpspreadsheet ^2 || ^3 || ^4 || ^5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "friendsofphp/php-cs-fixer": "^3.4",
         "matthiasnoback/symfony-config-test": "^6.1",
         "matthiasnoback/symfony-dependency-injection-test": "^6.2",
-        "phpoffice/phpspreadsheet": "^1.23",
+        "phpoffice/phpspreadsheet": "^1.23 || ^2.0 || ^3.3 || ^4.0 || ^5.0",
         "phpstan/extension-installer": "^1.0",
         "phpstan/phpdoc-parser": "^1.0",
         "phpstan/phpstan": "^1.0 || ^2.0",


### PR DESCRIPTION
## Summary

Widen the `phpoffice/phpspreadsheet` constraint in `require-dev` from `^1.23` to `^1.23 || ^2.0 || ^3.3 || ^4.0 || ^5.0`, so the test suite exercises the writer against the supported major versions of PhpSpreadsheet up to the current stable (5.x).

The library currently caps testing at `1.23.x` even though downstream projects regularly install PhpSpreadsheet 4.x / 5.x. Without this bump:
- CI never exercises the writer against modern releases.
- Static analysis is pinned to a stale set of upstream types.
- Consumers cannot easily verify compatibility from this repo.

## Compatibility check

I reviewed the BC-break sections of every major release of PhpSpreadsheet between 2.0 and 5.x against the APIs touched by `src/Writer/XlsxWriter.php` and `tests/Writer/XlsxWriterTest.php`:

| API used by `XlsxWriter` | Status across 2.x → 5.x |
| --- | --- |
| `Spreadsheet`, `Worksheet` | unchanged |
| `IOFactory::createReader` / `createWriter` | unchanged |
| `CellAddress::fromColumnAndRow` | unchanged |
| `DataType::TYPE_*` constants | unchanged |
| `NumberFormat::FORMAT_DATE_DDMMYYYY` | unchanged |
| `Date::PHPToExcel` | unchanged |
| `Worksheet::setCellValueExplicit` / `setAutoFilter` / `calculateWorksheetDimension` / `setSelectedCell` / `getStyle` | unchanged |
| `Writer\Exception` | unchanged |

2.0 was a typing-strengthening pass, 3.3 was dynamic arrays plus unrelated deprecation removals, 4.0 reworked data validations / conditional formatting / CSV Mac line ending auto-detection / HTML boolean rendering, and 5.0 made external images opt-in and tightened large-integer handling. None touch the surface used here, and `XlsxWriterTest` only reads the file back as CSV — a path unaffected by the 4.0 HTML/CSV changes (no booleans, no auto-detected line endings).

PHP requirement: PhpSpreadsheet 2.0+ requires `^8.1`, already a subset of this library's `^8.2`.

The `conflict` entry stays at `<1.23` since anything from 1.23 upwards is now supported.

## Test plan

- [ ] CI runs the existing `tests/Writer/XlsxWriterTest.php` against the upper bound of the constraint (composer should resolve to 5.x by default).
- [ ] PHPStan picks up the new typings from PhpSpreadsheet 5.x.